### PR TITLE
feat: ParsedValue type

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ In addition to providing a `check` method, funtypes can be used as [type guards]
 
 ```ts
 function disembark(obj: {}) {
-  if (SpaceObject.guard(obj)) {
+  if (SpaceObject.test(obj)) {
     // obj: SpaceObject
     if (obj.type === 'ship') {
       // obj: Ship
@@ -265,7 +265,7 @@ One important choice when changing `Constraint` static types is choosing the
 correct underlying type. The implementation of `Constraint` will validate the
 underlying type *before* running your constraint function. So it's important to
 use a lowest-common-denominator type that will pass validation for all expected
-inputs of your constraint function or type guard.  If there's no obvious
+inputs of your constraint function or type test.  If there's no obvious
 lowest-common-denominator type, you can always use `Unknown` as the underlying
 type, as shown in the `Buffer` examples above.  
 

--- a/src/asynccontract.ts
+++ b/src/asynccontract.ts
@@ -1,5 +1,12 @@
 import { ValidationError } from './errors';
-import { innerGuard, innerValidate, RuntypeBase } from './runtype';
+import {
+  createGuardVisitedState,
+  createVisitedState,
+  innerGuard,
+  innerValidate,
+  OpaqueVisitedState,
+  RuntypeBase,
+} from './runtype';
 
 export interface AsyncContract<A extends any[], Z> {
   enforce(f: (...a: A) => Promise<Z>): (...a: A) => Promise<Z>;
@@ -21,7 +28,7 @@ export function AsyncContract<A extends [any, ...any[]] | [], Z>(
           ),
         );
       }
-      const visited = new Map<RuntypeBase, Map<any, any>>();
+      const visited: OpaqueVisitedState = createVisitedState();
       for (let i = 0; i < argTypes.length; i++) {
         const result = innerValidate(argTypes[i], args[i], visited);
         if (result.success) {
@@ -39,7 +46,7 @@ export function AsyncContract<A extends [any, ...any[]] | [], Z>(
         );
       }
       return returnedPromise.then(value => {
-        const result = innerGuard(returnType, value, new Map());
+        const result = innerGuard(returnType, value, createGuardVisitedState());
         if (result) {
           throw new ValidationError(result.message, result.key);
         }

--- a/src/asynccontract.ts
+++ b/src/asynccontract.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from './errors';
-import { RuntypeBase } from './runtype';
+import { innerGuard, innerValidate, RuntypeBase } from './runtype';
 
 export interface AsyncContract<A extends any[], Z> {
   enforce(f: (...a: A) => Promise<Z>): (...a: A) => Promise<Z>;
@@ -21,10 +21,11 @@ export function AsyncContract<A extends [any, ...any[]] | [], Z>(
           ),
         );
       }
+      const visited = new Map<RuntypeBase, Map<any, any>>();
       for (let i = 0; i < argTypes.length; i++) {
-        const result = argTypes[i].validate(args[i]);
+        const result = innerValidate(argTypes[i], args[i], visited);
         if (result.success) {
-          argTypes[i] = result.value;
+          args[i] = result.value;
         } else {
           return Promise.reject(new ValidationError(result.message, result.key));
         }
@@ -38,12 +39,11 @@ export function AsyncContract<A extends [any, ...any[]] | [], Z>(
         );
       }
       return returnedPromise.then(value => {
-        const result = returnType.validate(value);
-        if (result.success) {
-          return result.value;
-        } else {
+        const result = innerGuard(returnType, value, new Map());
+        if (result) {
           throw new ValidationError(result.message, result.key);
         }
+        return value;
       });
     },
   };

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,4 +1,11 @@
-import { innerGuard, innerValidate, RuntypeBase } from './runtype';
+import {
+  createGuardVisitedState,
+  createVisitedState,
+  innerGuard,
+  innerValidate,
+  OpaqueVisitedState,
+  RuntypeBase,
+} from './runtype';
 import { ValidationError } from './errors';
 
 export interface Contract<A extends any[], Z> {
@@ -18,7 +25,7 @@ export function Contract<A extends [any, ...any[]] | [], Z>(
         throw new ValidationError(
           `Expected ${argTypes.length} arguments but only received ${args.length}`,
         );
-      const visited = new Map<RuntypeBase, Map<any, any>>();
+      const visited: OpaqueVisitedState = createVisitedState();
       for (let i = 0; i < argTypes.length; i++) {
         const result = innerValidate(argTypes[i], args[i], visited);
         if (result.success) {
@@ -28,7 +35,7 @@ export function Contract<A extends [any, ...any[]] | [], Z>(
         }
       }
       const rawResult = f(...args);
-      const result = innerGuard(returnType, rawResult, new Map());
+      const result = innerGuard(returnType, rawResult, createGuardVisitedState());
       if (result) {
         throw new ValidationError(result.message, result.key);
       }

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,4 +1,4 @@
-import { RuntypeBase } from './runtype';
+import { innerGuard, innerValidate, RuntypeBase } from './runtype';
 import { ValidationError } from './errors';
 
 export interface Contract<A extends any[], Z> {
@@ -18,20 +18,21 @@ export function Contract<A extends [any, ...any[]] | [], Z>(
         throw new ValidationError(
           `Expected ${argTypes.length} arguments but only received ${args.length}`,
         );
+      const visited = new Map<RuntypeBase, Map<any, any>>();
       for (let i = 0; i < argTypes.length; i++) {
-        const result = argTypes[i].validate(args[i]);
+        const result = innerValidate(argTypes[i], args[i], visited);
         if (result.success) {
-          argTypes[i] = result.value;
+          args[i] = result.value;
         } else {
           throw new ValidationError(result.message, result.key);
         }
       }
-      const result = returnType.validate(f(...args));
-      if (result.success) {
-        return result.value;
-      } else {
+      const rawResult = f(...args);
+      const result = innerGuard(returnType, rawResult, new Map());
+      if (result) {
         throw new ValidationError(result.message, result.key);
       }
+      return rawResult;
     },
   };
 }

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from './errors';
-import { innerValidate, RuntypeBase } from './runtype';
+import { createVisitedState, innerValidate, OpaqueVisitedState, RuntypeBase } from './runtype';
 
 type PropKey = string | symbol;
 const prototypes = new WeakMap<any, Map<PropKey, number[]>>();
@@ -75,7 +75,7 @@ export function checked(...runtypes: RuntypeBase<unknown>[]) {
       throw new Error('Number of `@checked` runtypes exceeds actual parameter length.');
     }
 
-    const visited = new Map<RuntypeBase, Map<any, any>>();
+    const visited: OpaqueVisitedState = createVisitedState();
     descriptor.value = function(...args: any[]) {
       runtypes.forEach((type, typeIndex) => {
         const parameterIndex = validParameterIndices[typeIndex];

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -725,7 +725,7 @@ describe('change static type with Constraint', () => {
       name: 'SomeClass',
     });
 
-    if (C.guard(value)) {
+    if (C.test(value)) {
       return value;
     } else {
       return new SomeClassV2(3);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -765,7 +765,7 @@ describe('change static type with Constraint', () => {
     | InstanceOf<Constructor<never>>
     | Brand<string, String | Number>,
 ) => {
-  const check = <A>(X: Runtype<A>): A => X.check({});
+  const check = <A>(X: Runtype<A>): A => X.parse({});
 
   switch (X.tag) {
     case 'unknown':
@@ -828,18 +828,18 @@ function expectLiteralField<O, K extends keyof O, V extends O[K]>(o: O, k: K, v:
 }
 
 function assertAccepts<A>(value: unknown, runtype: Runtype<A>) {
-  const result = runtype.validate(value);
+  const result = runtype.safeParse(value);
   if (result.success === false) fail(result.message);
 }
 
 function assertRejects<A>(value: unknown, runtype: Runtype<A>) {
-  const result = runtype.validate(value);
+  const result = runtype.safeParse(value);
   if (result.success === true) fail('value passed validation even though it was not expected to');
 }
 
 function assertThrows<A>(value: unknown, runtype: Runtype<A>, error: string, key?: string) {
   try {
-    runtype.check(value);
+    runtype.parse(value);
     fail('value passed validation even though it was not expected to');
   } catch (exception) {
     const { message: errorMessage, key: errorKey } = exception;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,4 +22,5 @@ export { InstanceOf } from './types/instanceof';
 export * from './types/lazy';
 export * from './types/constraint';
 export { Brand } from './types/brand';
+export { ParsedValue } from './types/ParsedValue';
 export * from './decorator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { Runtype, Static } from './runtype';
+export { Runtype, Codec, Static } from './runtype';
 export * from './result';
 export * from './contract';
 export * from './asynccontract';

--- a/src/runtype.spec.ts
+++ b/src/runtype.spec.ts
@@ -20,6 +20,9 @@ test('Runtype.assert', () => {
   expect(() => String.assert(42)).toThrowErrorMatchingInlineSnapshot(
     `"Expected string, but was number"`,
   );
+  expect(() => Record({ value: String }).assert({ value: 42 })).toThrowErrorMatchingInlineSnapshot(
+    `"Expected string, but was number in value"`,
+  );
 });
 
 test('Runtype.assert', () => {

--- a/src/runtype.spec.ts
+++ b/src/runtype.spec.ts
@@ -36,31 +36,31 @@ test('Runtype.check', () => {
   );
 });
 
-test('Runtype.guard', () => {
-  expect(String.guard('hello')).toBe(true);
-  expect(String.guard(42)).toBe(false);
+test('Runtype.test', () => {
+  expect(String.test('hello')).toBe(true);
+  expect(String.test(42)).toBe(false);
 });
 
 test('Runtype.Or', () => {
-  expect(String.Or(Number).guard('hello')).toBe(true);
-  expect(String.Or(Number).guard(42)).toBe(true);
-  expect(String.Or(Number).guard(true)).toBe(false);
+  expect(String.Or(Number).test('hello')).toBe(true);
+  expect(String.Or(Number).test(42)).toBe(true);
+  expect(String.Or(Number).test(true)).toBe(false);
 });
 
 test('Runtype.And', () => {
   expect(
     Record({ a: String })
       .And(Record({ b: Number }))
-      .guard({ a: 'hello', b: 42 }),
+      .test({ a: 'hello', b: 42 }),
   ).toBe(true);
   expect(
     Record({ a: String })
       .And(Record({ b: Number }))
-      .guard({ a: 42, b: 42 }),
+      .test({ a: 42, b: 42 }),
   ).toBe(false);
   expect(
     Record({ a: String })
       .And(Record({ b: Number }))
-      .guard({ a: 'hello', b: 'hello' }),
+      .test({ a: 'hello', b: 'hello' }),
   ).toBe(false);
 });

--- a/src/runtype.spec.ts
+++ b/src/runtype.spec.ts
@@ -1,13 +1,13 @@
 import { String, Number, Record } from './';
 
 test('Runtype.validate', () => {
-  expect(String.validate('hello')).toMatchInlineSnapshot(`
+  expect(String.safeParse('hello')).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": "hello",
     }
   `);
-  expect(String.validate(42)).toMatchInlineSnapshot(`
+  expect(String.safeParse(42)).toMatchInlineSnapshot(`
     Object {
       "message": "Expected string, but was number",
       "success": false,
@@ -30,8 +30,8 @@ test('Runtype.assert', () => {
 });
 
 test('Runtype.check', () => {
-  expect(String.check('hello')).toBe('hello');
-  expect(() => String.check(42)).toThrowErrorMatchingInlineSnapshot(
+  expect(String.parse('hello')).toBe('hello');
+  expect(() => String.parse(42)).toThrowErrorMatchingInlineSnapshot(
     `"Expected string, but was number"`,
   );
 });

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -390,10 +390,11 @@ export function innerSerialize(
   );
   if (result.cycle) {
     const { placeholder, populate } = result;
-    visited.set(targetType, (visited.get(targetType) || new Map()).set(value, placeholder));
+    const cache = (visited.get(targetType) || new Map()).set(value, placeholder);
+    visited.set(targetType, cache);
     result = populate();
     if (result.success) {
-      visited.set(targetType, (visited.get(targetType) || new Map()).set(value, result.value));
+      cache.set(value, result.value);
     }
   }
   return result;

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -19,6 +19,8 @@ export interface InternalValidation<TParsed> {
     innerValidate: <T>(runtype: RuntypeBase<T>, value: unknown) => Failure | undefined,
   ) => Failure | undefined;
   serialize?: (
+    // any is used here to ensure TypeScript still treats RuntypeBase as
+    // covariant.
     x: any,
     innerSerialize: (runtype: RuntypeBase, value: unknown) => Result<any>,
     innerSerializeToPlaceholder: (runtype: RuntypeBase, value: unknown) => ResultWithCycle<any>,
@@ -140,16 +142,16 @@ export interface Runtype<TParsed> extends RuntypeBase<TParsed> {
   withParser<TParsed>(value: ParsedValueConfig<this, TParsed>): ParsedValue<this, TParsed>;
 }
 
-export interface Codec<TParsed, TSerialized = TParsed> extends Runtype<TParsed> {
-  serialize: (x: TParsed) => TSerialized;
-  safeSerialize: (x: TParsed) => Result<TSerialized>;
+export interface Codec<TParsed> extends Runtype<TParsed> {
+  serialize: (x: TParsed) => unknown;
+  safeSerialize: (x: TParsed) => Result<unknown>;
 }
 /**
  * Obtains the static type associated with a Runtype.
  */
 export type Static<A extends RuntypeBase<any>> = A extends RuntypeBase<infer T> ? T : unknown;
 
-export function create<TConfig extends Codec<any, any>>(
+export function create<TConfig extends Codec<any>>(
   internalImplementation:
     | InternalValidation<Static<TConfig>>
     | InternalValidation<Static<TConfig>>['validate'],

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -29,25 +29,14 @@ export interface InternalValidation<TParsed> {
 /**
  * A runtype determines at runtime whether a value conforms to a type specification.
  */
-export interface RuntypeBase<A = unknown> {
+export interface RuntypeBase<TParsed = unknown> {
   readonly tag: string;
 
-  show?: (ctx: {
-    needsParens: boolean;
-    parenthesize: (str: string) => string;
-    showChild: (rt: RuntypeBase, needsParens: boolean) => string;
-  }) => string;
-
-  [internal]: InternalValidation<A>;
-}
-
-/**
- * A runtype determines at runtime whether a value conforms to a type specification.
- */
-export interface Runtype<TParsed> extends RuntypeBase<TParsed> {
   /**
    * Verifies that a value conforms to this runtype. When given a value that does
    * not conform to the runtype, throws an exception.
+   *
+   * @throws ValidationError
    */
   assert(x: any): asserts x is TParsed;
 
@@ -62,8 +51,13 @@ export interface Runtype<TParsed> extends RuntypeBase<TParsed> {
   guard(x: any): x is TParsed;
 
   /**
-   * Verifies that a value conforms to this runtype. If so, returns the same value,
-   * statically typed. Otherwise throws an exception.
+   * Validates the value conforms to this type, and performs
+   * the `parse` action for any `ParsedValue` types.
+   *
+   * If the value is valid, it returns the parsed value,
+   * otherwise it throws a ValidationError.
+   *
+   * @throws ValidationError
    */
   parse(x: any): TParsed;
 
@@ -73,8 +67,11 @@ export interface Runtype<TParsed> extends RuntypeBase<TParsed> {
   check(x: any): TParsed;
 
   /**
-   * Validates that a value conforms to this type, and returns a result indicating
-   * success or failure (does not throw).
+   * Validates the value conforms to this type, and performs
+   * the `parse` action for any `ParsedValue` types.
+   *
+   * Returns a `Result`, constaining the parsed value or
+   * error message. Does not throw!
    */
   safeParse(x: any): Result<TParsed>;
 
@@ -83,6 +80,19 @@ export interface Runtype<TParsed> extends RuntypeBase<TParsed> {
    */
   validate(x: any): Result<TParsed>;
 
+  show?: (ctx: {
+    needsParens: boolean;
+    parenthesize: (str: string) => string;
+    showChild: (rt: RuntypeBase, needsParens: boolean) => string;
+  }) => string;
+
+  [internal]: InternalValidation<TParsed>;
+}
+
+/**
+ * A runtype determines at runtime whether a value conforms to a type specification.
+ */
+export interface Runtype<TParsed> extends RuntypeBase<TParsed> {
   /**
    * Union this Runtype with another.
    */
@@ -143,7 +153,24 @@ export interface Runtype<TParsed> extends RuntypeBase<TParsed> {
 }
 
 export interface Codec<TParsed> extends Runtype<TParsed> {
+  /**
+   * Validates the value conforms to this type, and performs
+   * the `serialize` action for any `ParsedValue` types.
+   *
+   * If the value is valid, and the type supports serialize,
+   * it returns the serialized value, otherwise it throws a
+   * ValidationError.
+   *
+   * @throws ValidationError
+   */
   serialize: (x: TParsed) => unknown;
+  /**
+   * Validates the value conforms to this type, and performs
+   * the `serialize` action for any `ParsedValue` types.
+   *
+   * Returns a `Result`, constaining the serialized value or
+   * error message. Does not throw!
+   */
   safeSerialize: (x: TParsed) => Result<unknown>;
 }
 /**

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -274,29 +274,29 @@ export type Cycle<T> = {
   unwrap: () => Result<T>;
 };
 
-function attemptMixin<T>(placehoder: any, value: T): Result<T> {
-  if (placehoder === value) {
+function attemptMixin<T>(placeholder: any, value: T): Result<T> {
+  if (placeholder === value) {
     return { success: true, value };
   }
-  if (Array.isArray(placehoder) && Array.isArray(value)) {
-    placehoder.splice(0, placehoder.length, ...value);
-    return { success: true, value: placehoder as any };
+  if (Array.isArray(placeholder) && Array.isArray(value)) {
+    placeholder.splice(0, placeholder.length, ...value);
+    return { success: true, value: placeholder as any };
   }
   if (
-    placehoder &&
-    typeof placehoder === 'object' &&
-    !Array.isArray(placehoder) &&
+    placeholder &&
+    typeof placeholder === 'object' &&
+    !Array.isArray(placeholder) &&
     value &&
     typeof value === 'object' &&
     !Array.isArray(value)
   ) {
-    Object.assign(placehoder, value);
-    return { success: true, value: placehoder };
+    Object.assign(placeholder, value);
+    return { success: true, value: placeholder };
   }
   return {
     success: false,
     message: `Cannot convert a value of type "${
-      Array.isArray(placehoder) ? 'Array' : typeof placehoder
+      Array.isArray(placeholder) ? 'Array' : typeof placeholder
     }" into a value of type "${
       value === null ? 'null' : Array.isArray(value) ? 'Array' : typeof value
     }" when it contains cycles.`,
@@ -305,7 +305,7 @@ function attemptMixin<T>(placehoder: any, value: T): Result<T> {
 
 export function createValidationPlaceholder<T>(
   placeholder: T,
-  fn: (placehoder: T) => Failure | undefined,
+  fn: (placeholder: T) => Failure | undefined,
 ): Cycle<T> {
   return innerMapValidationPlaceholder(
     placeholder,
@@ -315,7 +315,7 @@ export function createValidationPlaceholder<T>(
 
 export function mapValidationPlaceholder<T, S>(
   source: ResultWithCycle<T>,
-  fn: (placehoder: T) => Result<S>,
+  fn: (placeholder: T) => Result<S>,
   extraGuard?: RuntypeBase<S>,
 ): ResultWithCycle<S> {
   if (!source.success) return source;
@@ -340,7 +340,7 @@ export function mapValidationPlaceholder<T, S>(
 function innerMapValidationPlaceholder(
   placeholder: any,
   populate: () => Result<any>,
-  fn?: (placehoder: any) => Result<any>,
+  fn?: (placeholder: any) => Result<any>,
   extraGuard?: RuntypeBase<any>,
 ): Cycle<any> {
   let hasCycle = false;
@@ -369,7 +369,6 @@ function innerMapValidationPlaceholder(
       } else {
         const guardFailure =
           extraGuard && innerGuard(extraGuard, result.value, createGuardVisitedState());
-        cycle.placeholder = result.value;
         cache = guardFailure || result;
       }
 

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -305,7 +305,7 @@ function attemptMixin<T>(placehoder: any, value: T): Result<T> {
 
 export function createValidationPlaceholder<T>(
   placeholder: T,
-  fn: (placehoder: T) => Result<T> | undefined,
+  fn: (placehoder: T) => Failure | undefined,
 ): Cycle<T> {
   return innerMapValidationPlaceholder(
     placeholder,
@@ -360,7 +360,7 @@ function innerMapValidationPlaceholder(
       const result = sourceResult.success && fn ? fn(sourceResult.value) : sourceResult;
       if (!result.success) return result;
       if (hasCycle) {
-        const unwrapResult = attemptMixin(placeholder, result.value);
+        const unwrapResult = attemptMixin(cache.value, result.value);
         const guardFailure =
           unwrapResult.success &&
           extraGuard &&
@@ -376,6 +376,7 @@ function innerMapValidationPlaceholder(
       if (cache.success) {
         cycle.placeholder = cache.value;
       }
+
       return cache;
     },
   };

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -5,7 +5,7 @@ import { ValidationError } from './errors';
 export type InnerValidateHelper = <T>(runtype: RuntypeBase<T>, value: unknown) => Result<T>;
 declare const internalSymbol: unique symbol;
 const internal: typeof internalSymbol = ('__internal__' as unknown) as typeof internalSymbol;
-interface InternalValidation<A> {
+export interface InternalValidation<A> {
   validate(
     x: any,
     innerValidate: <T>(runtype: RuntypeBase<T>, value: unknown) => Result<T>,
@@ -130,7 +130,7 @@ export interface Runtype<A = unknown> extends RuntypeBase<A> {
  */
 export type Static<A extends RuntypeBase<any>> = A extends RuntypeBase<infer T> ? T : unknown;
 
-export function create<TConfig extends RuntypeBase<any>>(
+export function create<TConfig extends Runtype<any>>(
   internalImplementation:
     | InternalValidation<Static<TConfig>>
     | InternalValidation<Static<TConfig>>['validate'],
@@ -149,24 +149,6 @@ export function create<TConfig extends RuntypeBase<any>>(
     | typeof internal
   >,
 ): TConfig {
-  // A.check = check;
-  // A.assert = (v: any) => {
-  //   check(v);
-  // };
-  // A._innerValidate = (value: any, visited: VisitedState) => {
-  //   if (visited.has(value, A)) return { success: true, value };
-  //   return validate(value, visited);
-  // };
-  // A.validate = (value: any) => A._innerValidate(value, VisitedState());
-  // A.test = test;
-  // A.Or = Or;
-  // A.And = And;
-  // A.withConstraint = withConstraint;
-  // A.withGuard = withGuard;
-  // A.withBrand = withBrand;
-  // A.reflect = A;
-  // A.toString = () => `Runtype<${show(A)}>`;
-
   const A: Runtype<Static<TConfig>> = {
     ...config,
     assert,

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -41,36 +41,36 @@ export interface RuntypeBase<A = unknown> {
 /**
  * A runtype determines at runtime whether a value conforms to a type specification.
  */
-export interface Runtype<A = unknown> extends RuntypeBase<A> {
+export interface Runtype<TParsed, TSerialized = TParsed> extends RuntypeBase<TParsed> {
   /**
    * Verifies that a value conforms to this runtype. When given a value that does
    * not conform to the runtype, throws an exception.
    */
-  assert(x: any): asserts x is A;
+  assert(x: any): asserts x is TParsed;
 
   /**
    * A type guard for this runtype.
    */
-  test(x: any): x is A;
+  test(x: any): x is TParsed;
 
   /**
    * A type guard for this runtype.
    *
    * @deprecated use Runtype.test instead
    */
-  guard(x: any): x is A;
+  guard(x: any): x is TParsed;
 
   /**
    * Verifies that a value conforms to this runtype. If so, returns the same value,
    * statically typed. Otherwise throws an exception.
    */
-  check(x: any): A;
+  check(x: any): TParsed;
 
   /**
    * Validates that a value conforms to this type, and returns a result indicating
    * success or failure (does not throw).
    */
-  validate(x: any): Result<A>;
+  validate(x: any): Result<TParsed>;
 
   /**
    * Union this Runtype with another.

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -260,7 +260,7 @@ export function createValidationPlaceholder<T>(
 }
 
 type VisitedState = Map<RuntypeBase<unknown>, Map<any, any>>;
-function innerValidate<T>(
+export function innerValidate<T>(
   targetType: RuntypeBase<T>,
   value: any,
   visited: VisitedState,
@@ -282,7 +282,7 @@ function innerValidate<T>(
   return result;
 }
 
-function innerGuard(
+export function innerGuard(
   targetType: RuntypeBase,
   value: any,
   visited: Map<RuntypeBase, Set<any>>,

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -1,6 +1,7 @@
 import { Result, Union, Intersect, Constraint, ConstraintCheck, Brand, Failure } from './index';
 import show from './show';
 import { ValidationError } from './errors';
+import { ParsedValue, ParsedValueConfig } from './types/ParsedValue';
 
 export type InnerValidateHelper = <T>(runtype: RuntypeBase<T>, value: unknown) => Result<T>;
 declare const internalSymbol: unique symbol;
@@ -123,6 +124,11 @@ export interface Runtype<A = unknown> extends RuntypeBase<A> {
    * Adds a brand to the type.
    */
   withBrand<B extends string>(brand: B): Brand<B, this>;
+
+  /**
+   * Apply conversion functions when parsing/serializing this value
+   */
+  withParser<TParsed>(value: ParsedValueConfig<this, TParsed>): ParsedValue<this, TParsed>;
 }
 
 /**
@@ -146,6 +152,7 @@ export function create<TConfig extends Runtype<any>>(
     | 'withConstraint'
     | 'withGuard'
     | 'withBrand'
+    | 'withParser'
     | typeof internal
   >,
 ): TConfig {
@@ -161,6 +168,7 @@ export function create<TConfig extends Runtype<any>>(
     withConstraint,
     withGuard,
     withBrand,
+    withParser,
     toString: () => `Runtype<${show(A)}>`,
     [internal]:
       typeof internalImplementation === 'function'
@@ -215,6 +223,12 @@ export function create<TConfig extends Runtype<any>>(
 
   function withBrand<B extends string>(B: B): Brand<B, Runtype<Static<TConfig>>> {
     return Brand<B, Runtype<Static<TConfig>>>(B, A);
+  }
+
+  function withParser<TParsed>(
+    config: ParsedValueConfig<Runtype<Static<TConfig>>, TParsed>,
+  ): ParsedValue<Runtype<Static<TConfig>>, TParsed> {
+    return ParsedValue(A as any, config);
   }
 }
 

--- a/src/show.ts
+++ b/src/show.ts
@@ -1,4 +1,5 @@
 import { RuntypeBase } from './runtype';
+import { isLazyRuntype } from './types/lazy';
 
 const show = (needsParens: boolean, circular: Set<RuntypeBase<unknown>>) => (
   runtype: RuntypeBase<unknown>,
@@ -8,6 +9,12 @@ const show = (needsParens: boolean, circular: Set<RuntypeBase<unknown>>) => (
     show(needsParens, circular)(runtype);
 
   if (circular.has(runtype)) {
+    if (isLazyRuntype(runtype)) {
+      const underlying = runtype.underlying();
+      if (underlying !== runtype) {
+        return show(needsParens, circular)(underlying);
+      }
+    }
     return parenthesize(`CIRCULAR ${runtype.tag}`);
   }
 

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -1,5 +1,6 @@
 import * as ta from 'type-assertions';
 import { String, Number, ParsedValue, Static, Literal, Record, Union } from '..';
+import { InstanceOf } from './instanceof';
 
 test('TrimmedString', () => {
   const TrimmedString = ParsedValue(String, {
@@ -17,6 +18,12 @@ test('TrimmedString', () => {
     Object {
       "success": true,
       "value": "foo bar",
+    }
+  `);
+  expect(TrimmedString.safeParse(42)).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected string, but was number",
+      "success": false,
     }
   `);
 
@@ -128,6 +135,39 @@ test('Upgrade Example', () => {
     Object {
       "key": "<version: 1>",
       "message": "ParsedValue<{ version: 1; size: number; }> does not support Runtype.serialize",
+      "success": false,
+    }
+  `);
+});
+
+test('URL', () => {
+  const URLString = ParsedValue(String, {
+    name: 'URLString',
+    parse(value) {
+      try {
+        return { success: true, value: new URL(value) };
+      } catch (ex) {
+        return { success: false, message: `Expected a valid URL but got '${value}'` };
+      }
+    },
+    test: InstanceOf(URL),
+  });
+
+  expect(URLString.safeParse('https://example.com')).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "https://example.com/",
+    }
+  `);
+  expect(URLString.safeParse(42)).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected string, but was number",
+      "success": false,
+    }
+  `);
+  expect(URLString.safeParse('not a url')).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected a valid URL but got 'not a url'",
       "success": false,
     }
   `);

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -355,7 +355,7 @@ test('Handle Being Outside Cycles - objects', () => {
     Record({ child: RecursiveTypeWithoutParse }),
   );
   const RecursiveType: Codec<RecursiveType, unknown> = Lazy(() =>
-    Record({ value: Union(String, Null), child: RecursiveTypeWithoutParse }).withParser({
+    Record({ value: Union(String, Null), child: RecursiveType }).withParser({
       parse({ value, ...rest }) {
         return {
           success: true,
@@ -366,7 +366,7 @@ test('Handle Being Outside Cycles - objects', () => {
         return {
           success: true,
           value: {
-            value: null,
+            value: 'hello world',
             child: obj.child,
           },
         };
@@ -375,24 +375,19 @@ test('Handle Being Outside Cycles - objects', () => {
     }),
   );
 
-  const example: RecursiveTypePreParse = { value: null, child: null as any };
+  const example: RecursiveTypePreParse = { value: 'hello world', child: null as any };
   example.child = example;
 
   const expected: RecursiveType = { child: null as any };
   expected.child = expected;
 
-  console.log('=== parse ===');
   const parsed = RecursiveType.parse(example);
-  console.log('=== parse end ===');
   expect(parsed).toEqual(expected);
 
   const serialized = RecursiveType.serialize(parsed);
   expect(serialized).toEqual(example);
 
   expect(() => RecursiveType.assert(parsed)).not.toThrow();
-  expect(() => RecursiveType.assert(serialized)).toThrowErrorMatchingInlineSnapshot(
-    `"Expected array, but was string in [0]"`,
-  );
 });
 
 test('Fails when cycles modify types', () => {

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -313,7 +313,7 @@ test('Handle Being Outside Cycles', () => {
   const RecursiveTypeWithoutParse: Codec<RecursiveType> = Lazy(() =>
     Array(RecursiveTypeWithoutParse),
   );
-  const RecursiveType: Codec<RecursiveType, RecursiveTypePreParse> = Lazy(() =>
+  const RecursiveType: Codec<RecursiveType> = Lazy(() =>
     Array(Union(String, RecursiveType)).withParser({
       parse(arr) {
         return {
@@ -354,7 +354,7 @@ test('Handle Being Outside Cycles - objects', () => {
   const RecursiveTypeWithoutParse: Codec<RecursiveType> = Lazy(() =>
     Record({ child: RecursiveTypeWithoutParse }),
   );
-  const RecursiveType: Codec<RecursiveType, unknown> = Lazy(() =>
+  const RecursiveType: Codec<RecursiveType> = Lazy(() =>
     Record({ value: Union(String, Null), child: RecursiveType }).withParser({
       parse({ value, ...rest }) {
         return {
@@ -396,7 +396,7 @@ test('Fails when cycles modify types', () => {
   const RecursiveTypeWithoutParse: Codec<RecursiveType> = Lazy(() =>
     Record({ values: Array(RecursiveTypeWithoutParse) }),
   );
-  const RecursiveType: Codec<RecursiveType, RecursiveTypePreParse> = Lazy(
+  const RecursiveType: Codec<RecursiveType> = Lazy(
     () =>
       Array(RecursiveType).withParser({
         name: 'Parser<Array ↔ Object>',

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -381,7 +381,9 @@ test('Handle Being Outside Cycles - objects', () => {
   const expected: RecursiveType = { child: null as any };
   expected.child = expected;
 
+  console.log('=== parse ===');
   const parsed = RecursiveType.parse(example);
+  console.log('=== parse end ===');
   expect(parsed).toEqual(expected);
 
   const serialized = RecursiveType.serialize(parsed);

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -1,6 +1,19 @@
 import * as ta from 'type-assertions';
-import { String, Number, ParsedValue, Static, Literal, Record, Union } from '..';
+import {
+  Array,
+  String,
+  Number,
+  ParsedValue,
+  Static,
+  Literal,
+  Record,
+  Union,
+  Tuple,
+  Codec,
+} from '..';
+import show from '../show';
 import { InstanceOf } from './instanceof';
+import { Lazy } from './lazy';
 
 test('TrimmedString', () => {
   const TrimmedString = ParsedValue(String, {
@@ -138,6 +151,17 @@ test('Upgrade Example', () => {
       "success": false,
     }
   `);
+
+  expect(Shape.serialize({ version: 2, width: 10, height: 20 })).toMatchInlineSnapshot(`
+    Object {
+      "height": 20,
+      "version": 2,
+      "width": 10,
+    }
+  `);
+  expect(() => Shape.serialize({ version: 1, size: 20 } as any)).toThrowErrorMatchingInlineSnapshot(
+    `"ParsedValue<{ version: 1; size: number; }> does not support Runtype.serialize in <version: 1>"`,
+  );
 });
 
 test('URL', () => {
@@ -153,6 +177,9 @@ test('URL', () => {
     test: InstanceOf(URL),
   });
 
+  const value: URL = URLString.parse('https://example.com');
+  expect(value).toBeInstanceOf(URL);
+  expect(value).toMatchInlineSnapshot(`"https://example.com/"`);
   expect(URLString.safeParse('https://example.com')).toMatchInlineSnapshot(`
     Object {
       "success": true,
@@ -171,4 +198,155 @@ test('URL', () => {
       "success": false,
     }
   `);
+});
+
+test('test is optional', () => {
+  const TrimmedString = ParsedValue<String, string>(String, {
+    name: 'TrimmedString',
+    parse(value) {
+      return { success: true, value: value.trim() };
+    },
+    serialize(value) {
+      // we're trusting the backend here, because there is no test!
+      return { success: true, value };
+    },
+  });
+  expect(() => TrimmedString.assert('foo bar')).toThrowErrorMatchingInlineSnapshot(
+    `"TrimmedString does not support Runtype.test"`,
+  );
+  expect(TrimmedString.safeSerialize(' value ')).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": " value ",
+    }
+  `);
+  // even though we're not testing before serialize, the value is still
+  // validated after it has been serialized
+  expect(TrimmedString.safeSerialize(42 as any)).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected string, but was number",
+      "success": false,
+    }
+  `);
+  expect(show(TrimmedString)).toMatchInlineSnapshot(`"TrimmedString"`);
+  const AnonymousStringTrim = ParsedValue(String, {
+    parse(value) {
+      return { success: true, value: value.trim() };
+    },
+  });
+  expect(() => AnonymousStringTrim.assert('foo bar')).toThrowErrorMatchingInlineSnapshot(
+    `"ParsedValue<string> does not support Runtype.test"`,
+  );
+  expect(show(AnonymousStringTrim)).toMatchInlineSnapshot(`"ParsedValue<string>"`);
+});
+
+test('serialize can return an error', () => {
+  const URLString = ParsedValue(String, {
+    name: 'URLString',
+    parse(value) {
+      try {
+        return { success: true, value: new URL(value) };
+      } catch (ex) {
+        return { success: false, message: `Expected a valid URL but got '${value}'` };
+      }
+    },
+    test: InstanceOf(URL),
+    serialize(value) {
+      if (value.protocol === 'https:') return { success: true, value: value.href };
+      else return { success: false, message: `Refusing to serialize insecure URL: ${value.href}` };
+    },
+  });
+
+  expect(URLString.safeSerialize(new URL('https://example.com'))).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "https://example.com/",
+    }
+  `);
+  expect(URLString.safeSerialize(new URL('http://example.com'))).toMatchInlineSnapshot(`
+    Object {
+      "message": "Refusing to serialize insecure URL: http://example.com/",
+      "success": false,
+    }
+  `);
+});
+
+test('Handle Being Within Cycles', () => {
+  const TrimmedString = ParsedValue(String, {
+    name: 'TrimmedString',
+    parse(value) {
+      return { success: true, value: value.trim() };
+    },
+    test: String.withConstraint(
+      value =>
+        value.trim() === value || `Expected the string to be trimmed, but this one has whitespace`,
+    ),
+    serialize(value) {
+      return { success: true, value: ` ${value} ` };
+    },
+  });
+  type RecursiveType = [string, RecursiveType];
+  const RecursiveType: Codec<RecursiveType> = Lazy(() => Tuple(TrimmedString, RecursiveType));
+
+  const example = [' hello world ', undefined as any] as RecursiveType;
+  example[1] = example;
+
+  const expected = ['hello world', undefined as any] as RecursiveType;
+  expected[1] = expected;
+
+  const parsed = RecursiveType.parse(example);
+  expect(parsed).toEqual(expected);
+
+  const serialized = RecursiveType.serialize(parsed);
+  expect(serialized).toEqual(example);
+
+  expect(() => RecursiveType.assert(parsed)).not.toThrow();
+  expect(() => RecursiveType.assert(serialized)).toThrowErrorMatchingInlineSnapshot(
+    `"Expected the string to be trimmed, but this one has whitespace in [0]"`,
+  );
+  // const RecursiveType = Tuple(Literal(1));
+});
+
+test('Handle Being Outside Cycles', () => {
+  type RecursiveTypePreParse = (string | RecursiveTypePreParse)[];
+  type RecursiveType = RecursiveType[];
+  const RecursiveTypeWithoutParse: Codec<RecursiveType> = Lazy(() => Array(RecursiveType));
+  const RecursiveType: Codec<RecursiveType, RecursiveTypePreParse> = Lazy(() =>
+    Array(Union(String, RecursiveType)).withParser({
+      parse(arr) {
+        // To use parse on data containing cycles, you have to mutate the existing value
+        // normally this is not advised, as it's harder to do without introducing bugs.
+        // You also cannot safely do this if there are any parsed types in the underlying type.
+        // Essetially, please don't do this!
+        arr.splice(
+          0,
+          arr.length,
+          ...arr.filter(<T>(value: T): value is Exclude<T, string> => typeof value !== 'string'),
+        );
+        return {
+          success: true,
+          value: arr as RecursiveType,
+        };
+      },
+      serialize(arr: RecursiveType) {
+        return { success: true, value: arr };
+      },
+      test: RecursiveTypeWithoutParse,
+    }),
+  );
+
+  const example: RecursiveTypePreParse = ['hello world'];
+  example.push(example);
+
+  const expected: RecursiveType = [];
+  expected.push(expected);
+
+  const parsed = RecursiveType.parse(example);
+  expect(parsed).toEqual(expected);
+
+  const serialized = RecursiveType.serialize(parsed);
+  expect(serialized).toEqual(example);
+
+  expect(() => RecursiveType.assert(parsed)).not.toThrow();
+  expect(() => RecursiveType.assert(serialized)).not.toThrow();
 });

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -13,7 +13,7 @@ test('TrimmedString', () => {
     ),
   });
 
-  expect(TrimmedString.validate(' foo bar ')).toMatchInlineSnapshot(`
+  expect(TrimmedString.safeParse(' foo bar ')).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": "foo bar",
@@ -35,7 +35,7 @@ test('DoubledNumber', () => {
     test: Number.withConstraint(value => value % 2 === 0 || `Expected an even number`),
   });
 
-  expect(DoubledNumber.validate(10)).toMatchInlineSnapshot(`
+  expect(DoubledNumber.safeParse(10)).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": 20,
@@ -47,7 +47,7 @@ test('DoubledNumber', () => {
   );
   expect(() => DoubledNumber.assert(12)).not.toThrow();
 
-  expect(DoubledNumber.serialize(10)).toMatchInlineSnapshot(`
+  expect(DoubledNumber.safeSerialize(10)).toMatchInlineSnapshot(`
     Object {
       "message": "DoubledNumber does not support Runtype.serialize",
       "success": false,
@@ -67,7 +67,7 @@ test('DoubledNumber - 2', () => {
     },
   });
 
-  expect(DoubledNumber.validate(10)).toMatchInlineSnapshot(`
+  expect(DoubledNumber.safeParse(10)).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": 20,
@@ -79,14 +79,14 @@ test('DoubledNumber - 2', () => {
   );
   expect(() => DoubledNumber.assert(12)).not.toThrow();
 
-  expect(DoubledNumber.serialize(10)).toMatchInlineSnapshot(`
+  expect(DoubledNumber.safeSerialize(10)).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": 5,
     }
   `);
 
-  expect(DoubledNumber.serialize(11)).toMatchInlineSnapshot(`
+  expect(DoubledNumber.safeSerialize(11)).toMatchInlineSnapshot(`
     Object {
       "message": "Expected an even number",
       "success": false,
@@ -108,13 +108,13 @@ test('Upgrade Example', () => {
   );
   type X = Static<typeof Shape>;
   ta.assert<ta.Equal<X, { version: 2; width: number; height: number }>>();
-  expect(Shape.check({ version: 1, size: 42 })).toEqual({ version: 2, width: 42, height: 42 });
-  expect(Shape.check({ version: 2, width: 10, height: 20 })).toEqual({
+  expect(Shape.parse({ version: 1, size: 42 })).toEqual({ version: 2, width: 42, height: 42 });
+  expect(Shape.parse({ version: 2, width: 10, height: 20 })).toEqual({
     version: 2,
     width: 10,
     height: 20,
   });
-  expect(Shape.serialize({ version: 2, width: 10, height: 20 })).toMatchInlineSnapshot(`
+  expect(Shape.safeSerialize({ version: 2, width: 10, height: 20 })).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Object {
@@ -124,7 +124,7 @@ test('Upgrade Example', () => {
       },
     }
   `);
-  expect(Shape.serialize({ version: 1, size: 20 } as any)).toMatchInlineSnapshot(`
+  expect(Shape.safeSerialize({ version: 1, size: 20 } as any)).toMatchInlineSnapshot(`
     Object {
       "key": "<version: 1>",
       "message": "ParsedValue<{ version: 1; size: number; }> does not support Runtype.serialize",

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -1,0 +1,48 @@
+import { String, Number, Result, ParsedValue } from '..';
+
+test('TrimmedString', () => {
+  const TrimmedString = ParsedValue(String, {
+    name: 'TrimmedString',
+    parse(value) {
+      return { success: true, value: value.trim() };
+    },
+    test: String.withConstraint(
+      value =>
+        value.trim() === value || `Expected the string to be trimmed, but this one has whitespace`,
+    ),
+  });
+
+  expect(TrimmedString.validate(' foo bar ')).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "foo bar",
+    }
+  `);
+
+  expect(() => TrimmedString.assert(' foo bar ')).toThrowErrorMatchingInlineSnapshot(
+    `"Expected the string to be trimmed, but this one has whitespace"`,
+  );
+  expect(() => TrimmedString.assert('foo bar')).not.toThrow();
+});
+
+test('DoubledNumber', () => {
+  const DoubledNumber = ParsedValue(Number, {
+    name: 'DoubledNumber',
+    parse(value): Result<number> {
+      return { success: true, value: value * 2 };
+    },
+    test: Number.withConstraint(value => value % 2 === 0 || `Expected an even number`),
+  });
+
+  expect(DoubledNumber.validate(10)).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": 20,
+    }
+  `);
+
+  expect(() => DoubledNumber.assert(11)).toThrowErrorMatchingInlineSnapshot(
+    `"Expected an even number"`,
+  );
+  expect(() => DoubledNumber.assert(12)).not.toThrow();
+});

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -1,4 +1,4 @@
-import { String, Number, Result, ParsedValue } from '..';
+import { String, Number, ParsedValue } from '..';
 
 test('TrimmedString', () => {
   const TrimmedString = ParsedValue(String, {
@@ -28,7 +28,29 @@ test('TrimmedString', () => {
 test('DoubledNumber', () => {
   const DoubledNumber = ParsedValue(Number, {
     name: 'DoubledNumber',
-    parse(value): Result<number> {
+    parse(value) {
+      return { success: true, value: value * 2 };
+    },
+    test: Number.withConstraint(value => value % 2 === 0 || `Expected an even number`),
+  });
+
+  expect(DoubledNumber.validate(10)).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": 20,
+    }
+  `);
+
+  expect(() => DoubledNumber.assert(11)).toThrowErrorMatchingInlineSnapshot(
+    `"Expected an even number"`,
+  );
+  expect(() => DoubledNumber.assert(12)).not.toThrow();
+});
+
+test('DoubledNumber - 2', () => {
+  const DoubledNumber = Number.withParser({
+    name: 'DoubledNumber',
+    parse(value) {
       return { success: true, value: value * 2 };
     },
     test: Number.withConstraint(value => value % 2 === 0 || `Expected an even number`),

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -1,4 +1,5 @@
-import { String, Number, ParsedValue } from '..';
+import * as ta from 'type-assertions';
+import { String, Number, ParsedValue, Static, Literal, Record, Union } from '..';
 
 test('TrimmedString', () => {
   const TrimmedString = ParsedValue(String, {
@@ -45,6 +46,13 @@ test('DoubledNumber', () => {
     `"Expected an even number"`,
   );
   expect(() => DoubledNumber.assert(12)).not.toThrow();
+
+  expect(DoubledNumber.serialize(10)).toMatchInlineSnapshot(`
+    Object {
+      "message": "DoubledNumber does not support Runtype.serialize",
+      "success": false,
+    }
+  `);
 });
 
 test('DoubledNumber - 2', () => {
@@ -54,6 +62,9 @@ test('DoubledNumber - 2', () => {
       return { success: true, value: value * 2 };
     },
     test: Number.withConstraint(value => value % 2 === 0 || `Expected an even number`),
+    serialize(value) {
+      return { success: true, value: value / 2 };
+    },
   });
 
   expect(DoubledNumber.validate(10)).toMatchInlineSnapshot(`
@@ -67,4 +78,57 @@ test('DoubledNumber - 2', () => {
     `"Expected an even number"`,
   );
   expect(() => DoubledNumber.assert(12)).not.toThrow();
+
+  expect(DoubledNumber.serialize(10)).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": 5,
+    }
+  `);
+
+  expect(DoubledNumber.serialize(11)).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected an even number",
+      "success": false,
+    }
+  `);
+});
+
+test('Upgrade Example', () => {
+  const ShapeV1 = Record({ version: Literal(1), size: Number });
+  const ShapeV2 = Record({ version: Literal(2), width: Number, height: Number });
+  const Shape = Union(
+    ShapeV1.withParser({
+      parse: ({ size }) => ({
+        success: true,
+        value: { version: 2 as const, width: size, height: size },
+      }),
+    }),
+    ShapeV2,
+  );
+  type X = Static<typeof Shape>;
+  ta.assert<ta.Equal<X, { version: 2; width: number; height: number }>>();
+  expect(Shape.check({ version: 1, size: 42 })).toEqual({ version: 2, width: 42, height: 42 });
+  expect(Shape.check({ version: 2, width: 10, height: 20 })).toEqual({
+    version: 2,
+    width: 10,
+    height: 20,
+  });
+  expect(Shape.serialize({ version: 2, width: 10, height: 20 })).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": Object {
+        "height": 20,
+        "version": 2,
+        "width": 10,
+      },
+    }
+  `);
+  expect(Shape.serialize({ version: 1, size: 20 } as any)).toMatchInlineSnapshot(`
+    Object {
+      "key": "<version: 1>",
+      "message": "ParsedValue<{ version: 1; size: number; }> does not support Runtype.serialize",
+      "success": false,
+    }
+  `);
 });

--- a/src/types/ParsedValue.ts
+++ b/src/types/ParsedValue.ts
@@ -11,7 +11,7 @@ import {
 import show from '../show';
 
 export interface ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>
-  extends Codec<TParsed, Static<TUnderlying>> {
+  extends Codec<TParsed> {
   readonly tag: 'parsed';
   readonly underlying: TUnderlying;
   readonly config: ParsedValueConfig<TUnderlying, TParsed>;

--- a/src/types/ParsedValue.ts
+++ b/src/types/ParsedValue.ts
@@ -1,5 +1,12 @@
 import { Result } from '../result';
-import { RuntypeBase, Static, create, Codec, innerGuard } from '../runtype';
+import {
+  RuntypeBase,
+  Static,
+  create,
+  Codec,
+  innerGuard,
+  createGuardVisitedState,
+} from '../runtype';
 import show from '../show';
 
 export interface ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>
@@ -41,7 +48,7 @@ export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
         }
 
         const testResult = config.test
-          ? innerGuard(config.test, parsed.value, new Map())
+          ? innerGuard(config.test, parsed.value, createGuardVisitedState())
           : undefined;
 
         return testResult || parsed;
@@ -65,7 +72,9 @@ export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
               `ParsedValue<${show(underlying)}>`} does not support Runtype.serialize`,
           };
         }
-        const testResult = config.test ? innerGuard(config.test, value, new Map()) : undefined;
+        const testResult = config.test
+          ? innerGuard(config.test, value, createGuardVisitedState())
+          : undefined;
 
         if (testResult) {
           return testResult;

--- a/src/types/ParsedValue.ts
+++ b/src/types/ParsedValue.ts
@@ -36,33 +36,13 @@ export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
   return create<ParsedValue<TUnderlying, TParsed>>(
     {
       validate: (value, _innerValidate, innerValidateToPlaceholder) => {
-        const validated = innerValidateToPlaceholder(underlying, value);
-
-        if (!validated.success) {
-          return validated;
-        }
-
-        if (!validated.cycle) {
-          const parsed = config.parse(validated.value as any);
-
-          if (!parsed.success) {
-            return parsed;
-          }
-
-          const testResult = config.test
-            ? innerGuard(config.test, parsed.value, createGuardVisitedState())
-            : undefined;
-
-          return testResult || parsed;
-        } else {
-          return mapValidationPlaceholder<any, TParsed>(
-            validated,
-            source => {
-              return config.parse(source);
-            },
-            config.test,
-          );
-        }
+        return mapValidationPlaceholder<any, TParsed>(
+          innerValidateToPlaceholder(underlying, value),
+          source => {
+            return config.parse(source);
+          },
+          config.test,
+        );
       },
       test(value, internalTest) {
         if (config.test) {

--- a/src/types/ParsedValue.ts
+++ b/src/types/ParsedValue.ts
@@ -1,4 +1,4 @@
-import { Failure, Result } from '../result';
+import { Result } from '../result';
 import { RuntypeBase, Static, create, Codec, innerGuard } from '../runtype';
 import show from '../show';
 
@@ -19,7 +19,7 @@ export interface ParsedValueConfig<TUnderlying extends RuntypeBase<unknown>, TPa
   name?: string;
   parse: (value: Static<TUnderlying>) => Result<TParsed>;
   serialize?: (value: TParsed) => Result<Static<TUnderlying>>;
-  test?: RuntypeBase<TParsed> | ((x: any) => Failure | undefined);
+  test?: RuntypeBase<TParsed>;
 }
 export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
   underlying: TUnderlying,
@@ -40,19 +40,14 @@ export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
           return parsed;
         }
 
-        const testResult =
-          typeof config.test === 'function'
-            ? config.test(parsed.value)
-            : config.test
-            ? innerGuard(config.test, parsed.value, new Map())
-            : undefined;
+        const testResult = config.test
+          ? innerGuard(config.test, parsed.value, new Map())
+          : undefined;
 
         return testResult || parsed;
       },
       test(value, internalTest) {
-        if (typeof config.test === 'function') {
-          return config.test(value);
-        } else if (config.test) {
+        if (config.test) {
           return internalTest(config.test, value);
         } else {
           return {
@@ -70,12 +65,7 @@ export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
               `ParsedValue<${show(underlying)}>`} does not support Runtype.serialize`,
           };
         }
-        const testResult =
-          typeof config.test === 'function'
-            ? config.test(value)
-            : config.test
-            ? innerGuard(config.test, value, new Map())
-            : undefined;
+        const testResult = config.test ? innerGuard(config.test, value, new Map()) : undefined;
 
         if (testResult) {
           return testResult;

--- a/src/types/ParsedValue.ts
+++ b/src/types/ParsedValue.ts
@@ -1,0 +1,69 @@
+import { Failure, Result } from '../result';
+import { RuntypeBase, Static, create, Runtype, innerGuard } from '../runtype';
+import show from '../show';
+
+export interface ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>
+  extends Runtype<TParsed> {
+  readonly tag: 'parsed';
+  readonly underlying: TUnderlying;
+  readonly name?: string;
+  parse(value: Static<TUnderlying>): Result<TParsed>;
+}
+
+export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
+  underlying: TUnderlying,
+  config: {
+    name?: string;
+    parse: (value: Static<TUnderlying>) => Result<TParsed>;
+    test?: RuntypeBase<TParsed> | ((x: any) => Failure | undefined);
+  },
+): ParsedValue<TUnderlying, TParsed> {
+  return create<ParsedValue<TUnderlying, TParsed>>(
+    {
+      validate: (value, innerValidate) => {
+        const validated = innerValidate(underlying, value);
+
+        if (!validated.success) {
+          return validated;
+        }
+
+        const parsed = config.parse(value);
+
+        if (!parsed.success) {
+          return parsed;
+        }
+
+        const testResult =
+          typeof config.test === 'function'
+            ? config.test(parsed.value)
+            : config.test
+            ? innerGuard(config.test, parsed.value, new Map())
+            : undefined;
+
+        return testResult || parsed;
+      },
+      test(value, internalTest) {
+        if (typeof config.test === 'function') {
+          return config.test(value);
+        } else if (config.test) {
+          return internalTest(config.test, value);
+        } else {
+          return {
+            success: false,
+            message: `${config.name ||
+              `ParsedValue<${show(underlying)}>`} does not support Runtype.test`,
+          };
+        }
+      },
+    },
+    {
+      ...config,
+      tag: 'parsed',
+      underlying,
+
+      show({ showChild }) {
+        return config.name || `ParsedValue<${showChild(underlying, false)}>`;
+      },
+    },
+  );
+}

--- a/src/types/ParsedValue.ts
+++ b/src/types/ParsedValue.ts
@@ -6,10 +6,14 @@ export interface ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>
   extends Runtype<TParsed> {
   readonly tag: 'parsed';
   readonly underlying: TUnderlying;
-  readonly name?: string;
-  parse(value: Static<TUnderlying>): Result<TParsed>;
+  readonly config: ParsedValueConfig<TUnderlying, TParsed>;
 }
 
+export interface ParsedValueConfig<TUnderlying extends RuntypeBase<unknown>, TParsed> {
+  name?: string;
+  parse: (value: Static<TUnderlying>) => Result<TParsed>;
+  test?: RuntypeBase<TParsed> | ((x: any) => Failure | undefined);
+}
 export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
   underlying: TUnderlying,
   config: {
@@ -57,9 +61,9 @@ export function ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>(
       },
     },
     {
-      ...config,
       tag: 'parsed',
       underlying,
+      config,
 
       show({ showChild }) {
         return config.name || `ParsedValue<${showChild(underlying, false)}>`;

--- a/src/types/ParsedValue.ts
+++ b/src/types/ParsedValue.ts
@@ -9,6 +9,12 @@ export interface ParsedValue<TUnderlying extends RuntypeBase<unknown>, TParsed>
   readonly config: ParsedValueConfig<TUnderlying, TParsed>;
 }
 
+export function isParsedValueRuntype(
+  runtype: RuntypeBase,
+): runtype is ParsedValue<RuntypeBase, unknown> {
+  return 'tag' in runtype && (runtype as ParsedValue<RuntypeBase, unknown>).tag === 'parsed';
+}
+
 export interface ParsedValueConfig<TUnderlying extends RuntypeBase<unknown>, TParsed> {
   name?: string;
   parse: (value: Static<TUnderlying>) => Result<TParsed>;

--- a/src/types/array.spec.ts
+++ b/src/types/array.spec.ts
@@ -7,7 +7,7 @@ const record = { value: 42 };
 test('Array', () => {
   const dictionary = Array(recordType);
   ta.assert<ta.Equal<ReturnType<typeof dictionary['check']>, { value: 42 }[]>>();
-  expect(dictionary.validate([record, record, record])).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse([record, record, record])).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Array [
@@ -23,7 +23,7 @@ test('Array', () => {
       ],
     }
   `);
-  expect(dictionary.validate([record, 10, record])).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse([record, 10, record])).toMatchInlineSnapshot(`
     Object {
       "key": "[1]",
       "message": "Expected { value: 42; }, but was number",
@@ -35,7 +35,7 @@ test('Array', () => {
 test('Array.asReadonly', () => {
   const dictionary = Array(recordType).asReadonly();
   ta.assert<ta.Equal<ReturnType<typeof dictionary['check']>, readonly { value: 42 }[]>>();
-  expect(dictionary.validate([record, record, record])).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse([record, record, record])).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Array [
@@ -51,7 +51,7 @@ test('Array.asReadonly', () => {
       ],
     }
   `);
-  expect(dictionary.validate([record, 10, record])).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse([record, 10, record])).toMatchInlineSnapshot(`
     Object {
       "key": "[1]",
       "message": "Expected { value: 42; }, but was number",
@@ -63,7 +63,7 @@ test('Array.asReadonly', () => {
 test('ReadonlyArray', () => {
   const dictionary = ReadonlyArray(recordType);
   ta.assert<ta.Equal<ReturnType<typeof dictionary['check']>, readonly { value: 42 }[]>>();
-  expect(dictionary.validate([record, record, record])).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse([record, record, record])).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Array [
@@ -79,7 +79,7 @@ test('ReadonlyArray', () => {
       ],
     }
   `);
-  expect(dictionary.validate([record, 10, record])).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse([record, 10, record])).toMatchInlineSnapshot(`
     Object {
       "key": "[1]",
       "message": "Expected { value: 42; }, but was number",

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -1,14 +1,14 @@
-import { Static, create, RuntypeBase, Runtype, createValidationPlaceholder } from '../runtype';
+import { Static, create, RuntypeBase, Codec, createValidationPlaceholder } from '../runtype';
 
 export interface ReadonlyArray<E extends RuntypeBase<unknown> = RuntypeBase<unknown>>
-  extends Runtype<readonly Static<E>[]> {
+  extends Codec<readonly Static<E>[]> {
   readonly tag: 'array';
   readonly element: E;
   readonly isReadonly: true;
 }
 
 export { Arr as Array };
-interface Arr<E extends RuntypeBase<unknown> = RuntypeBase<unknown>> extends Runtype<Static<E>[]> {
+interface Arr<E extends RuntypeBase<unknown> = RuntypeBase<unknown>> extends Codec<Static<E>[]> {
   readonly tag: 'array';
   readonly element: E;
   readonly isReadonly: false;

--- a/src/types/boolean.ts
+++ b/src/types/boolean.ts
@@ -1,6 +1,6 @@
-import { create, Runtype } from '../runtype';
+import { create, Codec } from '../runtype';
 
-export interface Boolean extends Runtype<boolean> {
+export interface Boolean extends Codec<boolean> {
   readonly tag: 'boolean';
 }
 

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -19,11 +19,8 @@ export function isBrandRuntype(runtype: RuntypeBase): runtype is Brand<string, R
 
 export function Brand<B extends string, A extends RuntypeBase<unknown>>(brand: B, entity: A) {
   return create<Brand<B, A>>(
-    (value, innerValidate) => {
-      const validated = innerValidate(entity, value);
-      return validated.success
-        ? { success: true, value: validated.value as Static<Brand<B, A>> }
-        : validated;
+    (value, _innerValidate, innerValidateToPlaceholder) => {
+      return innerValidateToPlaceholder(entity, value) as any;
     },
     {
       tag: 'brand',

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -1,9 +1,9 @@
-import { RuntypeBase, Static, create, Runtype } from '../runtype';
+import { RuntypeBase, Static, create, Codec } from '../runtype';
 
 export const RuntypeName = Symbol('RuntypeName');
 
 export interface Brand<B extends string, A extends RuntypeBase<unknown>>
-  extends Runtype<
+  extends Codec<
     Static<A> & {
       [RuntypeName]: B;
     }

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -13,6 +13,10 @@ export interface Brand<B extends string, A extends RuntypeBase<unknown>>
   readonly entity: A;
 }
 
+export function isBrandRuntype(runtype: RuntypeBase): runtype is Brand<string, RuntypeBase> {
+  return 'tag' in runtype && (runtype as Brand<string, RuntypeBase>).tag === 'brand';
+}
+
 export function Brand<B extends string, A extends RuntypeBase<unknown>>(brand: B, entity: A) {
   return create<Brand<B, A>>(
     (value, innerValidate) => {

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -15,8 +15,8 @@ export interface Brand<B extends string, A extends RuntypeBase<unknown>>
 
 export function Brand<B extends string, A extends RuntypeBase<unknown>>(brand: B, entity: A) {
   return create<Brand<B, A>>(
-    value => {
-      const validated = entity.validate(value);
+    (value, innerValidate) => {
+      const validated = innerValidate(entity, value);
       return validated.success
         ? { success: true, value: validated.value as Static<Brand<B, A>> }
         : validated;

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -37,7 +37,7 @@ export function Constraint<
       }
 
       const result = constraint(validated.value as any);
-      if (String.guard(result)) return { success: false, message: result };
+      if (String.test(result)) return { success: false, message: result };
       else if (!result) return { success: false, message: `Failed ${name || 'constraint'} check` };
       return { success: true, value: validated.value as TConstrained };
     },
@@ -56,6 +56,6 @@ export function Constraint<
 }
 
 export const Guard = <T, K = unknown>(
-  guard: (x: unknown) => x is T,
+  test: (x: unknown) => x is T,
   options?: { name?: string; args?: K },
-) => Unknown.withGuard(guard, options);
+) => Unknown.withGuard(test, options);

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -1,4 +1,4 @@
-import { RuntypeBase, Static, create, innerValidate, Runtype } from '../runtype';
+import { RuntypeBase, Static, create, Runtype } from '../runtype';
 import { String } from './string';
 import { Unknown } from './unknown';
 
@@ -28,9 +28,9 @@ export function Constraint<
   options?: { name?: string; args?: TArgs },
 ): Constraint<TUnderlying, TConstrained, TArgs> {
   return create<Constraint<TUnderlying, TConstrained, TArgs>>(
-    (value, visited) => {
+    (value, innerValidate) => {
       const name = options && options.name;
-      const validated = innerValidate(underlying, value, visited);
+      const validated = innerValidate(underlying, value);
 
       if (!validated.success) {
         return validated;

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -1,4 +1,4 @@
-import { RuntypeBase, Static, create, Runtype } from '../runtype';
+import { RuntypeBase, Static, create, Codec } from '../runtype';
 import { String } from './string';
 import { Unknown } from './unknown';
 
@@ -16,7 +16,7 @@ export interface Constraint<
   TUnderlying extends RuntypeBase<unknown>,
   TConstrained extends Static<TUnderlying> = Static<TUnderlying>,
   TArgs = unknown
-> extends Runtype<TConstrained> {
+> extends Codec<TConstrained> {
   readonly tag: 'constraint';
   readonly underlying: TUnderlying;
   // See: https://github.com/Microsoft/TypeScript/issues/19746 for why this isn't just

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -4,6 +4,14 @@ import { Unknown } from './unknown';
 
 export type ConstraintCheck<A extends RuntypeBase<unknown>> = (x: Static<A>) => boolean | string;
 
+export function isConstraintRuntype(
+  runtype: RuntypeBase,
+): runtype is Constraint<RuntypeBase, unknown, unknown> {
+  return (
+    'tag' in runtype && (runtype as Constraint<RuntypeBase, unknown, unknown>).tag === 'constraint'
+  );
+}
+
 export interface Constraint<
   TUnderlying extends RuntypeBase<unknown>,
   TConstrained extends Static<TUnderlying> = Static<TUnderlying>,

--- a/src/types/dictionary.spec.ts
+++ b/src/types/dictionary.spec.ts
@@ -9,7 +9,7 @@ test('StringDictionary', () => {
   ta.assert<
     ta.Equal<ReturnType<typeof dictionary['check']>, { [key in string]?: { value: 42 } }>
   >();
-  expect(dictionary.validate({ foo: record, bar: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ foo: record, bar: record })).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Object {
@@ -22,7 +22,7 @@ test('StringDictionary', () => {
       },
     }
   `);
-  expect(dictionary.validate({ foo: record, bar: { value: 24 } })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ foo: record, bar: { value: 24 } })).toMatchInlineSnapshot(`
     Object {
       "key": "bar.value",
       "message": "Expected literal '42', but was '24'",
@@ -36,7 +36,7 @@ test('NumberDictionary', () => {
   ta.assert<
     ta.Equal<ReturnType<typeof dictionary['check']>, { [key in number]?: { value: 42 } }>
   >();
-  expect(dictionary.validate({ 4: record, 3.14: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ 4: record, 3.14: record })).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Object {
@@ -49,7 +49,7 @@ test('NumberDictionary', () => {
       },
     }
   `);
-  expect(dictionary.validate({ foo: record, bar: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ foo: record, bar: record })).toMatchInlineSnapshot(`
     Object {
       "message": "Expected dictionary key to be a number, but was 'foo'",
       "success": false,
@@ -65,7 +65,7 @@ test('IntegerDictionary', () => {
   ta.assert<
     ta.Equal<ReturnType<typeof dictionary['check']>, { [key in number]?: { value: 42 } }>
   >();
-  expect(dictionary.validate({ 4: record, 2: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ 4: record, 2: record })).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Object {
@@ -78,7 +78,7 @@ test('IntegerDictionary', () => {
       },
     }
   `);
-  expect(dictionary.validate({ 4: record, 3.14: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ 4: record, 3.14: record })).toMatchInlineSnapshot(`
     Object {
       "message": "Expected dictionary key to be Integer, but was '3.14'",
       "success": false,
@@ -91,7 +91,7 @@ test('UnionDictionary - strings', () => {
   ta.assert<
     ta.Equal<ReturnType<typeof dictionary['check']>, { [key in 'foo' | 'bar']?: { value: 42 } }>
   >();
-  expect(dictionary.validate({ foo: record, bar: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ foo: record, bar: record })).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Object {
@@ -104,7 +104,7 @@ test('UnionDictionary - strings', () => {
       },
     }
   `);
-  expect(dictionary.validate({ 10: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ 10: record })).toMatchInlineSnapshot(`
     Object {
       "message": "Expected dictionary key to be \\"foo\\" | \\"bar\\", but was '10'",
       "success": false,
@@ -116,7 +116,7 @@ test('UnionDictionary - numbers', () => {
   ta.assert<
     ta.Equal<ReturnType<typeof dictionary['check']>, { [key in 24 | 42]?: { value: 42 } }>
   >();
-  expect(dictionary.validate({ 24: record, 42: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ 24: record, 42: record })).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Object {
@@ -129,7 +129,7 @@ test('UnionDictionary - numbers', () => {
       },
     }
   `);
-  expect(dictionary.validate({ 10: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ 10: record })).toMatchInlineSnapshot(`
     Object {
       "message": "Expected dictionary key to be 24 | 42, but was '10'",
       "success": false,
@@ -141,7 +141,7 @@ test('UnionDictionary - mixed', () => {
   ta.assert<
     ta.Equal<ReturnType<typeof dictionary['check']>, { [key in 'foo' | 42]?: { value: 42 } }>
   >();
-  expect(dictionary.validate({ foo: record, 42: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ foo: record, 42: record })).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": Object {
@@ -154,7 +154,7 @@ test('UnionDictionary - mixed', () => {
       },
     }
   `);
-  expect(dictionary.validate({ foo: record, bar: record })).toMatchInlineSnapshot(`
+  expect(dictionary.safeParse({ foo: record, bar: record })).toMatchInlineSnapshot(`
     Object {
       "message": "Expected dictionary key to be \\"foo\\" | 42, but was 'bar'",
       "success": false,

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -1,4 +1,4 @@
-import { create, Static, RuntypeBase, Runtype, createValidationPlaceholder } from '../runtype';
+import { create, Static, RuntypeBase, Codec, createValidationPlaceholder } from '../runtype';
 import show from '../show';
 import { String } from './string';
 import { Number } from './number';
@@ -35,7 +35,7 @@ function getExpectedBaseType(key: KeyRuntypeBase): 'string' | 'number' | 'mixed'
 }
 
 export interface Dictionary<K extends KeyRuntypeBase, V extends RuntypeBase<unknown>>
-  extends Runtype<{ [_ in Static<K>]?: Static<V> }> {
+  extends Codec<{ [_ in Static<K>]?: Static<V> }> {
   readonly tag: 'dictionary';
   readonly key: K;
   readonly value: V;

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -1,4 +1,4 @@
-import { create, Static, innerValidate, RuntypeBase, Runtype } from '../runtype';
+import { create, Static, RuntypeBase, Runtype, createValidationPlaceholder } from '../runtype';
 import show from '../show';
 import { String } from './string';
 import { Number } from './number';
@@ -6,6 +6,7 @@ import { Literal } from './literal';
 import { Constraint } from './constraint';
 import { lazyValue } from './lazy';
 import { Union } from './union';
+import { Result } from '../result';
 
 export type KeyRuntypeBaseWithoutUnion =
   | Pick<String, keyof RuntypeBase>
@@ -49,7 +50,7 @@ export function Dictionary<K extends KeyRuntypeBase, V extends RuntypeBase<unkno
 ): Dictionary<K, V> {
   const expectedBaseType = lazyValue(() => getExpectedBaseType(key));
   const runtype: Dictionary<K, V> = create<Dictionary<K, V>>(
-    (x, visited) => {
+    (x, innerValidate) => {
       if (x === null || x === undefined) {
         return { success: false, message: `Expected ${show(runtype)}, but was ${x}` };
       }
@@ -68,38 +69,42 @@ export function Dictionary<K extends KeyRuntypeBase, V extends RuntypeBase<unkno
         return { success: false, message: 'Expected dictionary, but was array' };
       }
 
-      for (const k in x) {
-        let success = false;
-        if (expectedBaseType() === 'number') {
-          if (isNaN(+k))
+      return createValidationPlaceholder<{ [_ in Static<K>]?: Static<V> }>({}, placeholder => {
+        for (const k in x) {
+          let keyValidation: Result<string | number> | null = null;
+          if (expectedBaseType() === 'number') {
+            if (isNaN(+k))
+              return {
+                success: false,
+                message: `Expected dictionary key to be a number, but was '${k}'`,
+              };
+            keyValidation = innerValidate(key, +k);
+          } else if (expectedBaseType() === 'string') {
+            keyValidation = innerValidate(key, k);
+          } else {
+            keyValidation = innerValidate(key, k);
+            if (!keyValidation.success && !isNaN(+k)) {
+              keyValidation = innerValidate(key, +k);
+            }
+          }
+          if (!keyValidation.success) {
             return {
               success: false,
-              message: `Expected dictionary key to be a number, but was '${k}'`,
+              message: `Expected dictionary key to be ${show(key)}, but was '${k}'`,
             };
-          success = key.validate(+k).success;
-        } else if (expectedBaseType() === 'string') {
-          success = key.validate(k).success;
-        } else {
-          success = key.validate(k).success || (!isNaN(+k) && key.validate(+k).success);
-        }
-        if (!success) {
-          return {
-            success: false,
-            message: `Expected dictionary key to be ${show(key)}, but was '${k}'`,
-          };
-        }
+          }
 
-        const validated = innerValidate(value, (x as any)[k], visited);
-        if (!validated.success) {
-          return {
-            success: false,
-            message: validated.message,
-            key: validated.key ? `${k}.${validated.key}` : k,
-          };
+          const validated = innerValidate(value, (x as any)[k]);
+          if (!validated.success) {
+            return {
+              success: false,
+              message: validated.message,
+              key: validated.key ? `${k}.${validated.key}` : k,
+            };
+          }
+          (placeholder as any)[keyValidation.value] = validated.value;
         }
-      }
-
-      return { success: true, value: x };
+      });
     },
     {
       tag: 'dictionary',

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -1,6 +1,6 @@
-import { create, Runtype } from '../runtype';
+import { create, Codec } from '../runtype';
 
-export interface Function extends Runtype<(...args: any[]) => any> {
+export interface Function extends Codec<(...args: any[]) => any> {
   readonly tag: 'function';
 }
 

--- a/src/types/instanceof.ts
+++ b/src/types/instanceof.ts
@@ -1,10 +1,10 @@
-import { create, Runtype } from '../runtype';
+import { create, Codec } from '../runtype';
 
 export interface Constructor<V> {
   new (...args: any[]): V;
 }
 
-export interface InstanceOf<V = unknown> extends Runtype<V> {
+export interface InstanceOf<V = unknown> extends Codec<V> {
   readonly tag: 'instanceof';
   readonly ctor: Constructor<V>;
 }

--- a/src/types/intersect.spec.ts
+++ b/src/types/intersect.spec.ts
@@ -1,0 +1,113 @@
+import { Intersect, ParsedValue, Record, String, Tuple, Unknown } from '..';
+
+// This is a super odd/unhelpful type that just JSON.stringify's whatever you
+// attempt to parse
+const ConvertIntoJSON = Unknown.withParser({
+  name: 'ConvertIntoJSON',
+  parse(value) {
+    return { success: true, value: JSON.stringify(value) };
+  },
+});
+
+test('Intersect can handle object keys being converted', () => {
+  const URLString = ParsedValue(String, {
+    name: 'URLString',
+    parse(value) {
+      try {
+        return { success: true, value: new URL(value) };
+      } catch (ex) {
+        return { success: false, message: `Expected a valid URL but got '${value}'` };
+      }
+    },
+  });
+  const NameRecord = Record({ name: String });
+  const UrlRecord = Record({ url: URLString });
+  const NamedURL = Intersect(NameRecord, UrlRecord);
+
+  expect(NamedURL.safeParse({ name: 'example', url: 'http://example.com/foo/../' }))
+    .toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": Object {
+        "name": "example",
+        "url": "http://example.com/",
+      },
+    }
+  `);
+
+  expect(NamedURL.safeParse({ name: 'example', url: 'not a url' })).toMatchInlineSnapshot(`
+    Object {
+      "key": "url",
+      "message": "Expected a valid URL but got 'not a url'",
+      "success": false,
+    }
+  `);
+
+  expect(
+    Intersect(NamedURL, ConvertIntoJSON).safeParse({
+      name: 'example',
+      url: 'http://example.com/foo/../',
+    }),
+  ).toMatchInlineSnapshot(`
+    Object {
+      "message": "The validator ConvertIntoJSON attempted to convert the type of this value from an object to something else. That conversion is not valid as the child of an intersect",
+      "success": false,
+    }
+  `);
+});
+
+test('Intersect can handle tuple entries being converted', () => {
+  const URLString = ParsedValue(String, {
+    name: 'URLString',
+    parse(value) {
+      try {
+        return { success: true, value: new URL(value) };
+      } catch (ex) {
+        return { success: false, message: `Expected a valid URL but got '${value}'` };
+      }
+    },
+  });
+  const NameRecord = Tuple(String, Unknown);
+  const UrlRecord = Tuple(Unknown, URLString);
+  const NamedURL = Intersect(NameRecord, UrlRecord);
+  expect(NamedURL.safeParse(['example', 'http://example.com/foo/../'])).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": Array [
+        "example",
+        "http://example.com/",
+      ],
+    }
+  `);
+  expect(NamedURL.safeParse(['example', 'not a url'])).toMatchInlineSnapshot(`
+    Object {
+      "key": "[1]",
+      "message": "Expected a valid URL but got 'not a url'",
+      "success": false,
+    }
+  `);
+
+  expect(Intersect(NamedURL, ConvertIntoJSON).safeParse(['example', 'http://example.com/foo/../']))
+    .toMatchInlineSnapshot(`
+    Object {
+      "message": "The validator ConvertIntoJSON attempted to convert the type of this value from an array to something else. That conversion is not valid as the child of an intersect",
+      "success": false,
+    }
+  `);
+});
+
+test('Intersect can handle String + Brand', () => {
+  expect(Intersect(String, Unknown.withBrand('my_brand')).safeParse('hello world'))
+    .toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "hello world",
+    }
+  `);
+  expect(Intersect(String, Unknown.withBrand('my_brand')).safeParse(42)).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected string, but was number",
+      "success": false,
+    }
+  `);
+});

--- a/src/types/intersect.ts
+++ b/src/types/intersect.ts
@@ -41,7 +41,7 @@ export function Intersect<
                 )} attempted to convert the type of this value from an array to something else. That conversion is not valid as the child of an intersect`,
               };
             }
-            placeholder.splice(0, placeholder.length, validated.value);
+            placeholder.splice(0, placeholder.length, ...validated.value);
           }
         });
       } else if (value && typeof value === 'object') {
@@ -71,7 +71,6 @@ export function Intersect<
         }
         result = validated.value;
       }
-      // TODO: merge the maps
       return { success: true, value: result };
     },
     {

--- a/src/types/intersect.ts
+++ b/src/types/intersect.ts
@@ -1,4 +1,4 @@
-import { Static, create, RuntypeBase, Runtype, createValidationPlaceholder } from '../runtype';
+import { Static, create, RuntypeBase, Codec, createValidationPlaceholder } from '../runtype';
 import show from '../show';
 
 // We use the fact that a union of functions is effectively an intersection of parameters
@@ -13,7 +13,7 @@ export type StaticIntersect<TIntersectees extends readonly RuntypeBase<unknown>[
 
 export interface Intersect<
   TIntersectees extends readonly [RuntypeBase<unknown>, ...RuntypeBase<unknown>[]]
-> extends Runtype<StaticIntersect<TIntersectees>> {
+> extends Codec<StaticIntersect<TIntersectees>> {
   readonly tag: 'intersect';
   readonly intersectees: TIntersectees;
 }

--- a/src/types/lazy.ts
+++ b/src/types/lazy.ts
@@ -28,8 +28,8 @@ export function Lazy<TUnderlying extends RuntypeBase<unknown>>(
   const underlying = lazyValue(delayed);
 
   return create<Lazy<TUnderlying>>(
-    (value, innerValidate) => {
-      return innerValidate(underlying(), value) as any;
+    (value, _innerValidate, innerValidateToPlaceholder) => {
+      return innerValidateToPlaceholder(underlying(), value) as any;
     },
     {
       tag: 'lazy',

--- a/src/types/lazy.ts
+++ b/src/types/lazy.ts
@@ -19,9 +19,6 @@ export function lazyValue<T>(fn: () => T) {
 export function isLazyRuntype(runtype: RuntypeBase): runtype is Lazy<RuntypeBase> {
   return 'tag' in runtype && (runtype as Lazy<RuntypeBase<unknown>>).tag === 'lazy';
 }
-export function resolveLazyRuntype(runtype: RuntypeBase): RuntypeBase {
-  return isLazyRuntype(runtype) ? runtype.underlying() : runtype;
-}
 
 /**
  * Construct a possibly-recursive Runtype.

--- a/src/types/lazy.ts
+++ b/src/types/lazy.ts
@@ -1,4 +1,4 @@
-import { create, RuntypeBase, Runtype, innerValidate, Static } from '../runtype';
+import { create, RuntypeBase, Runtype, Static } from '../runtype';
 
 export interface Lazy<TUnderlying extends RuntypeBase<unknown>>
   extends Runtype<Static<TUnderlying>> {
@@ -32,8 +32,8 @@ export function Lazy<TUnderlying extends RuntypeBase<unknown>>(
   const underlying = lazyValue(delayed);
 
   return create<Lazy<TUnderlying>>(
-    (...args) => {
-      return innerValidate(underlying(), ...args);
+    (value, innerValidate) => {
+      return innerValidate(underlying(), value) as any;
     },
     {
       tag: 'lazy',

--- a/src/types/lazy.ts
+++ b/src/types/lazy.ts
@@ -1,7 +1,6 @@
-import { create, RuntypeBase, Runtype, Static } from '../runtype';
+import { create, RuntypeBase, Codec, Static } from '../runtype';
 
-export interface Lazy<TUnderlying extends RuntypeBase<unknown>>
-  extends Runtype<Static<TUnderlying>> {
+export interface Lazy<TUnderlying extends RuntypeBase<unknown>> extends Codec<Static<TUnderlying>> {
   readonly tag: 'lazy';
   readonly underlying: () => TUnderlying;
 }

--- a/src/types/literal.ts
+++ b/src/types/literal.ts
@@ -1,4 +1,4 @@
-import { RuntypeBase, create, Runtype } from '../runtype';
+import { RuntypeBase, create, Codec } from '../runtype';
 
 /**
  * The super type of all literal types.
@@ -6,7 +6,7 @@ import { RuntypeBase, create, Runtype } from '../runtype';
 export type LiteralValue = undefined | null | boolean | number | string;
 
 export interface Literal<TLiteralValue extends LiteralValue = LiteralValue>
-  extends Runtype<TLiteralValue> {
+  extends Codec<TLiteralValue> {
   readonly tag: 'literal';
   readonly value: TLiteralValue;
 }

--- a/src/types/never.ts
+++ b/src/types/never.ts
@@ -1,6 +1,6 @@
 import { Codec, create } from '../runtype';
 
-export interface Never extends Codec<never, never> {
+export interface Never extends Codec<never> {
   readonly tag: 'never';
 }
 

--- a/src/types/never.ts
+++ b/src/types/never.ts
@@ -1,16 +1,16 @@
-import { Runtype, create } from '../runtype';
+import { Codec, create } from '../runtype';
 
-export interface Never extends Runtype<never> {
+export interface Never extends Codec<never, never> {
   readonly tag: 'never';
 }
 
 /**
  * Validates nothing (unknown fails).
  */
-export const Never: Never = create<Never>(
+export const Never: Never = create(
   value => ({
     success: false,
     message: `Expected nothing, but was ${value === null ? value : typeof value}`,
   }),
   { tag: 'never' },
-);
+) as any;

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -1,6 +1,6 @@
-import { Runtype, create } from '../runtype';
+import { Codec, create } from '../runtype';
 
-export interface Number extends Runtype<number> {
+export interface Number extends Codec<number> {
   readonly tag: 'number';
 }
 

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,4 +1,4 @@
-import { Static, create, RuntypeBase, Runtype, createValidationPlaceholder } from '../runtype';
+import { Static, create, RuntypeBase, Codec, createValidationPlaceholder } from '../runtype';
 import { hasKey } from '../util';
 import show from '../show';
 
@@ -19,7 +19,7 @@ export interface InternalRecord<
   O extends RecordFields,
   IsPartial extends boolean,
   IsReadonly extends boolean
-> extends Runtype<RecordStaticType<O, IsPartial, IsReadonly>> {
+> extends Codec<RecordStaticType<O, IsPartial, IsReadonly>> {
   readonly tag: 'record';
   readonly fields: O;
   readonly isPartial: IsPartial;

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,4 +1,4 @@
-import { Static, create, innerValidate, RuntypeBase, Runtype } from '../runtype';
+import { Static, create, RuntypeBase, Runtype, createValidationPlaceholder } from '../runtype';
 import { hasKey } from '../util';
 import show from '../show';
 
@@ -57,7 +57,7 @@ export function InternalRecord<O extends RecordFields, Part extends boolean, RO 
   isReadonly: RO,
 ): InternalRecord<O, Part, RO> {
   const runtype: InternalRecord<O, Part, RO> = create<InternalRecord<O, Part, RO>>(
-    (x, visited) => {
+    (x, innerValidate) => {
       if (x === null || x === undefined) {
         return { success: false, message: `Expected ${show(runtype)}, but was ${x}` };
       }
@@ -68,21 +68,22 @@ export function InternalRecord<O extends RecordFields, Part extends boolean, RO 
         return { success: false, message: `Expected ${show(runtype)}, but was an Array` };
       }
 
-      for (const key in fields) {
-        if (!isPartial || (hasKey(key, x) && x[key] !== undefined)) {
-          const value = isPartial || hasKey(key, x) ? x[key] : undefined;
-          let validated = innerValidate(fields[key], value, visited);
-          if (!validated.success) {
-            return {
-              success: false,
-              message: validated.message,
-              key: validated.key ? `${key}.${validated.key}` : key,
-            };
+      return createValidationPlaceholder({} as any, (placeholder: any) => {
+        for (const key in fields) {
+          if (!isPartial || (hasKey(key, x) && x[key] !== undefined)) {
+            const value = isPartial || hasKey(key, x) ? x[key] : undefined;
+            let validated = innerValidate(fields[key], value);
+            if (!validated.success) {
+              return {
+                success: false,
+                message: validated.message,
+                key: validated.key ? `${key}.${validated.key}` : key,
+              };
+            }
+            placeholder[key] = validated.value;
           }
         }
-      }
-
-      return { success: true, value: x };
+      });
     },
     {
       tag: 'record',

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -1,6 +1,6 @@
-import { create, Runtype } from '../runtype';
+import { create, Codec } from '../runtype';
 
-export interface String extends Runtype<string> {
+export interface String extends Codec<string> {
   readonly tag: 'string';
 }
 

--- a/src/types/symbol.ts
+++ b/src/types/symbol.ts
@@ -1,6 +1,6 @@
-import { Runtype, create } from '../runtype';
+import { Codec, create } from '../runtype';
 
-interface Sym extends Runtype<symbol> {
+interface Sym extends Codec<symbol> {
   readonly tag: 'symbol';
 }
 

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -1,4 +1,4 @@
-import { create, RuntypeBase, Runtype, createValidationPlaceholder } from '../runtype';
+import { create, RuntypeBase, Codec, createValidationPlaceholder } from '../runtype';
 import { Array as Arr } from './array';
 import { Unknown } from './unknown';
 
@@ -8,7 +8,7 @@ export type StaticTuple<TElements extends readonly RuntypeBase<unknown>[]> = {
 
 export interface Tuple<
   TElements extends readonly RuntypeBase<unknown>[] = readonly RuntypeBase<unknown>[]
-> extends Runtype<StaticTuple<TElements>> {
+> extends Codec<StaticTuple<TElements>> {
   readonly tag: 'tuple';
   readonly components: TElements;
 }

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -22,7 +22,7 @@ describe('union', () => {
 
       const Shape = Union(Square, Rectangle, Circle);
 
-      expect(Shape.validate({ kind: 'square', size: new Date() })).toMatchInlineSnapshot(`
+      expect(Shape.safeParse({ kind: 'square', size: new Date() })).toMatchInlineSnapshot(`
         Object {
           "key": "<kind: 'square'>.size",
           "message": "Expected number, but was object",
@@ -30,7 +30,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate({ kind: 'rectangle', size: new Date() })).toMatchInlineSnapshot(`
+      expect(Shape.safeParse({ kind: 'rectangle', size: new Date() })).toMatchInlineSnapshot(`
         Object {
           "key": "<kind: 'rectangle'>.width",
           "message": "Expected number, but was undefined",
@@ -38,7 +38,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate({ kind: 'circle', size: new Date() })).toMatchInlineSnapshot(`
+      expect(Shape.safeParse({ kind: 'circle', size: new Date() })).toMatchInlineSnapshot(`
         Object {
           "key": "<kind: 'circle'>.radius",
           "message": "Expected number, but was undefined",
@@ -46,7 +46,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate({ kind: 'other', size: new Date() })).toMatchInlineSnapshot(`
+      expect(Shape.safeParse({ kind: 'other', size: new Date() })).toMatchInlineSnapshot(`
         Object {
           "key": "kind",
           "message": "Expected 'square' | 'rectangle' | 'circle', but was 'other'",
@@ -54,7 +54,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate(42)).toMatchInlineSnapshot(`
+      expect(Shape.safeParse(42)).toMatchInlineSnapshot(`
         Object {
           "message": "Expected { kind: \\"square\\"; size: number; } | { kind: \\"rectangle\\"; width: number; height: number; } | { kind: \\"circle\\"; radius: number; }, but was number",
           "success": false,
@@ -69,7 +69,7 @@ describe('union', () => {
 
       const Shape = Union(Square, Rectangle, CircularSquare);
 
-      expect(Shape.validate({ kind: 'square', size: new Date() })).not.toHaveProperty('key');
+      expect(Shape.safeParse({ kind: 'square', size: new Date() })).not.toHaveProperty('key');
     });
 
     it('should not pick alternative if not all types are records', () => {
@@ -78,7 +78,7 @@ describe('union', () => {
 
       const Shape = Union(Square, Rectangle, InstanceOf(Date));
 
-      expect(Shape.validate({ kind: 'square', size: new Date() })).not.toHaveProperty('key');
+      expect(Shape.safeParse({ kind: 'square', size: new Date() })).not.toHaveProperty('key');
     });
 
     it('should handle tuples where the first component is a literal tag', () => {
@@ -88,7 +88,7 @@ describe('union', () => {
 
       const Shape = Union(Square, Rectangle, Circle);
 
-      expect(Shape.validate(['square', { size: new Date() }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse(['square', { size: new Date() }])).toMatchInlineSnapshot(`
         Object {
           "key": "<[0]: 'square'>.[1].size",
           "message": "Expected number, but was object",
@@ -96,7 +96,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate(['rectangle', { size: new Date() }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse(['rectangle', { size: new Date() }])).toMatchInlineSnapshot(`
         Object {
           "key": "<[0]: 'rectangle'>.[1].width",
           "message": "Expected number, but was undefined",
@@ -104,7 +104,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate(['circle', { size: new Date() }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse(['circle', { size: new Date() }])).toMatchInlineSnapshot(`
         Object {
           "key": "<[0]: 'circle'>.[1].radius",
           "message": "Expected number, but was undefined",
@@ -112,7 +112,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate(['other', { size: new Date() }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse(['other', { size: new Date() }])).toMatchInlineSnapshot(`
         Object {
           "key": "[0]",
           "message": "Expected 'square' | 'rectangle' | 'circle', but was 'other'",
@@ -128,7 +128,7 @@ describe('union', () => {
 
       const Shape = Union(Square, Rectangle, Circle);
 
-      expect(Shape.validate(['rectangle', { size: new Date() }])).not.toHaveProperty('key');
+      expect(Shape.safeParse(['rectangle', { size: new Date() }])).not.toHaveProperty('key');
     });
 
     it('hould not pick alternative if the tuple has no discriminant', () => {
@@ -138,7 +138,7 @@ describe('union', () => {
 
       const Shape = Union(Square, Rectangle, Circle);
 
-      expect(Shape.validate(['rectangle', { size: new Date() }])).not.toHaveProperty('key');
+      expect(Shape.safeParse(['rectangle', { size: new Date() }])).not.toHaveProperty('key');
     });
 
     it('should handle numeric tags', () => {
@@ -147,7 +147,7 @@ describe('union', () => {
 
       const Shape = Union(Version1, Version2);
 
-      expect(Shape.validate([1, { size: 10 }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse([1, { size: 10 }])).toMatchInlineSnapshot(`
         Object {
           "success": true,
           "value": Array [
@@ -159,7 +159,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate([2, { size: 10 }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse([2, { size: 10 }])).toMatchInlineSnapshot(`
         Object {
           "key": "<[0]: 2>.[1].width",
           "message": "Expected number, but was undefined",
@@ -167,7 +167,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate([2, { width: 10, height: 20 }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse([2, { width: 10, height: 20 }])).toMatchInlineSnapshot(`
         Object {
           "success": true,
           "value": Array [
@@ -180,7 +180,7 @@ describe('union', () => {
         }
       `);
 
-      expect(Shape.validate([3, { size: 10 }])).toMatchInlineSnapshot(`
+      expect(Shape.safeParse([3, { size: 10 }])).toMatchInlineSnapshot(`
         Object {
           "key": "[0]",
           "message": "Expected 1 | 2, but was 3",

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,4 +1,13 @@
-import { Codec, Static, create, RuntypeBase, InnerValidateHelper, innerValidate } from '../runtype';
+import {
+  Codec,
+  Static,
+  create,
+  RuntypeBase,
+  InnerValidateHelper,
+  innerValidate,
+  createVisitedState,
+  OpaqueVisitedState,
+} from '../runtype';
 import show from '../show';
 import { LiteralValue, isLiteralRuntype } from './literal';
 import { lazyValue, isLazyRuntype } from './lazy';
@@ -182,7 +191,7 @@ export function Union<
 
   function match(...cases: any[]) {
     return (x: any) => {
-      const visited = new Map<RuntypeBase, Map<any, any>>();
+      const visited: OpaqueVisitedState = createVisitedState();
       for (let i = 0; i < alternatives.length; i++) {
         const input = innerValidate(alternatives[i], x, visited);
         if (input.success) {

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -134,13 +134,28 @@ export function Union<
         }
       }
       return (value, innerValidate) => {
+        let errorsWithKey = 0;
+        let lastError;
+        let lastErrorRuntype;
         for (const targetType of alternatives) {
           const result = innerValidate(targetType, value);
           if (result.success) {
             return result as Result<TResult>;
           }
+          if (result.key) {
+            errorsWithKey++;
+            lastError = result;
+            lastErrorRuntype = targetType;
+          }
         }
 
+        if (lastError && lastErrorRuntype && errorsWithKey === 1) {
+          return {
+            success: false,
+            message: lastError.message,
+            key: `<${show(lastErrorRuntype)}>.${lastError.key}`,
+          };
+        }
         return {
           success: false,
           message: `Expected ${show(runtype)}, but was ${value === null ? value : typeof value}`,

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,11 +1,4 @@
-import {
-  Runtype,
-  Static,
-  create,
-  RuntypeBase,
-  InnerValidateHelper,
-  innerValidate,
-} from '../runtype';
+import { Codec, Static, create, RuntypeBase, InnerValidateHelper, innerValidate } from '../runtype';
 import show from '../show';
 import { LiteralValue, isLiteralRuntype } from './literal';
 import { lazyValue, isLazyRuntype } from './lazy';
@@ -23,7 +16,7 @@ export type StaticUnion<TAlternatives extends readonly RuntypeBase<unknown>[]> =
 }[number];
 
 export interface Union<TAlternatives extends readonly RuntypeBase<unknown>[]>
-  extends Runtype<StaticUnion<TAlternatives>> {
+  extends Codec<StaticUnion<TAlternatives>> {
   readonly tag: 'union';
   readonly alternatives: TAlternatives;
   match: Match<TAlternatives>;

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,4 +1,11 @@
-import { Runtype, Static, create, RuntypeBase, InnerValidateHelper } from '../runtype';
+import {
+  Runtype,
+  Static,
+  create,
+  RuntypeBase,
+  InnerValidateHelper,
+  innerValidate,
+} from '../runtype';
 import show from '../show';
 import { LiteralValue, isLiteralRuntype } from './literal';
 import { lazyValue, resolveLazyRuntype } from './lazy';
@@ -154,8 +161,9 @@ export function Union<
 
   function match(...cases: any[]) {
     return (x: any) => {
+      const visited = new Map<RuntypeBase, Map<any, any>>();
       for (let i = 0; i < alternatives.length; i++) {
-        const input = alternatives[i].validate(x);
+        const input = innerValidate(alternatives[i], x, visited);
         if (input.success) {
           return cases[i](input.value);
         }

--- a/src/types/unknown.ts
+++ b/src/types/unknown.ts
@@ -1,6 +1,6 @@
-import { Runtype, create } from '../runtype';
+import { Codec, create } from '../runtype';
 
-export interface Unknown extends Runtype<unknown> {
+export interface Unknown extends Codec<unknown> {
   readonly tag: 'unknown';
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-// Type guard to determine if an object has a given key
+// Type test to determine if an object has a given key
 // If this feature gets implemented, we can use `in` instead: https://github.com/Microsoft/TypeScript/issues/10485
 export function hasKey<K extends string>(k: K, o: {}): o is { [_ in K]: {} } {
   return typeof o === 'object' && k in o;


### PR DESCRIPTION
This allows you to define a type that has a different representation for parsed vs. serialized data. The `serialize` method is left as optional, which lets you create parse-only codecs for legacy data while always serializing to the latest format