### PR TITLE
fix: handle test and serialize properly in unions of parsed values

### DIFF
--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -147,8 +147,8 @@ test('Upgrade Example', () => {
   `);
   expect(Shape.safeSerialize({ version: 1, size: 20 } as any)).toMatchInlineSnapshot(`
     Object {
-      "key": "<version: 1>",
-      "message": "ParsedValue<{ version: 1; size: number; }> does not support Runtype.serialize",
+      "key": "version",
+      "message": "Expected 2, but was 1",
       "success": false,
     }
   `);
@@ -161,7 +161,7 @@ test('Upgrade Example', () => {
     }
   `);
   expect(() => Shape.serialize({ version: 1, size: 20 } as any)).toThrowErrorMatchingInlineSnapshot(
-    `"ParsedValue<{ version: 1; size: number; }> does not support Runtype.serialize in <version: 1>"`,
+    `"Expected 2, but was 1 in version"`,
   );
 });
 


### PR DESCRIPTION
The optimisation was mistakenly assuming data always had the un-parsed structure, when in fact serialize and test operate on the parsed data. This change also introduces a new optimisation of excluding never and excluding parsed values that do not have a serialize method