### PR TITLE
feat: enum helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Boolean } from './types/boolean';
 export type { ConstraintCheck } from './types/constraint';
 export { Constraint, Guard } from './types/constraint';
 export { Dictionary } from './types/dictionary';
+export { Enum } from './types/Enum';
 export { Function } from './types/function';
 export { InstanceOf } from './types/instanceof';
 export { Intersect } from './types/intersect';

--- a/src/types/Enum.spec.ts
+++ b/src/types/Enum.spec.ts
@@ -1,0 +1,50 @@
+import { Enum } from '..';
+
+enum NumericEnum {
+  foo = 12,
+  bar = 20,
+}
+enum StringEnum {
+  Foo = 'Bar',
+  Helo = 'World',
+}
+
+test('Numeric Enum', () => {
+  expect(Enum('NumericEnum', NumericEnum).safeParse(12)).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": 12,
+    }
+  `);
+  expect(Enum('NumericEnum', NumericEnum).safeParse(16)).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected NumericEnum, but was '16'",
+      "success": false,
+    }
+  `);
+  expect(Enum('NumericEnum', NumericEnum).safeParse('bar')).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected NumericEnum, but was 'bar'",
+      "success": false,
+    }
+  `);
+  const typed: NumericEnum = Enum('NumericEnum', NumericEnum).parse(20);
+  expect(typed).toBe(NumericEnum.bar);
+});
+
+test('String Enum', () => {
+  expect(Enum('StringEnum', StringEnum).safeParse('World')).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "World",
+    }
+  `);
+  expect(Enum('StringEnum', StringEnum).safeParse('Hello')).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected StringEnum, but was 'Hello'",
+      "success": false,
+    }
+  `);
+  const typed: StringEnum = Enum('StringEnum', StringEnum).parse('Bar');
+  expect(typed).toBe(StringEnum.Foo);
+});

--- a/src/types/Enum.spec.ts
+++ b/src/types/Enum.spec.ts
@@ -1,4 +1,5 @@
 import { Enum } from '..';
+import show from '../show';
 
 enum NumericEnum {
   foo = 12,
@@ -30,6 +31,8 @@ test('Numeric Enum', () => {
   `);
   const typed: NumericEnum = Enum('NumericEnum', NumericEnum).parse(20);
   expect(typed).toBe(NumericEnum.bar);
+
+  expect(show(Enum('NumericEnum', NumericEnum))).toMatchInlineSnapshot(`"NumericEnum"`);
 });
 
 test('String Enum', () => {

--- a/src/types/Enum.ts
+++ b/src/types/Enum.ts
@@ -1,0 +1,34 @@
+import { create, Codec } from '../runtype';
+
+export interface Enum<TEnum extends { [key: string]: number | string }>
+  extends Codec<TEnum[keyof TEnum]> {
+  readonly tag: 'enum';
+  readonly enumObject: TEnum;
+}
+
+export function Enum<TEnum extends { [key: string]: number | string }>(
+  name: string,
+  e: TEnum,
+): Enum<TEnum> {
+  const values = Object.values(e);
+  const enumValues = new Set(
+    values.some(v => typeof v === 'number') ? values.filter(v => typeof v === 'number') : values,
+  );
+  return create<Enum<TEnum>>(
+    value => {
+      if (enumValues.has(value as any)) {
+        return { success: true, value: value as any };
+      } else {
+        return {
+          success: false,
+          message: `Expected ${name}, but was '${value}'`,
+        };
+      }
+    },
+    {
+      tag: 'enum',
+      enumObject: e,
+      show: () => name,
+    },
+  );
+}


### PR DESCRIPTION
This takes in an enum object and generates a type safe parser for it. It can handle both string and number based enums.