### PR TITLE
feat: add `Readonly` utility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export { Named } from './types/Named';
 export { Never } from './types/never';
 export { Object, Partial } from './types/Object';
 export { Boolean, Function, Number, String, Symbol } from './types/primative';
+export { Readonly } from './types/Readonly';
 export { Record } from './types/Record';
 export { Tuple } from './types/tuple';
 export { Union } from './types/union';

--- a/src/types/Readonly.spec.ts
+++ b/src/types/Readonly.spec.ts
@@ -1,0 +1,67 @@
+import * as ta from 'type-assertions';
+import * as ft from '..';
+
+test('Readonly(Record)', () => {
+  const dictionary = ft.Record(ft.String, ft.Number);
+  ta.assert<ta.Equal<ReturnType<typeof dictionary['parse']>, { [key in string]?: number }>>();
+  const rDictionary = ft.Readonly(dictionary);
+  ta.assert<
+    ta.Equal<ReturnType<typeof rDictionary['parse']>, { readonly [key in string]?: number }>
+  >();
+  expect(rDictionary.safeParse({ foo: 1, bar: 2 })).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": Object {
+        "bar": 2,
+        "foo": 1,
+      },
+    }
+  `);
+});
+
+test('Readonly(Object)', () => {
+  const obj = ft.Object({ whatever: ft.Number });
+  ta.assert<ta.Equal<ReturnType<typeof obj['parse']>, { whatever: number }>>();
+  const rObj = ft.Readonly(obj);
+  ta.assert<ta.Equal<ReturnType<typeof rObj['parse']>, { readonly whatever: number }>>();
+  expect(rObj.safeParse({ whatever: 2 })).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": Object {
+        "whatever": 2,
+      },
+    }
+  `);
+});
+
+test('Readonly(Tuple)', () => {
+  const tuple = ft.Tuple(ft.Number, ft.String);
+  ta.assert<ta.Equal<ReturnType<typeof tuple['parse']>, [number, string]>>();
+  const rTuple = ft.Readonly(tuple);
+  ta.assert<ta.Equal<ReturnType<typeof rTuple['parse']>, readonly [number, string]>>();
+  expect(rTuple.safeParse([10, `world`])).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": Array [
+        10,
+        "world",
+      ],
+    }
+  `);
+});
+
+test('Readonly(Array)', () => {
+  const array = ft.Array(ft.Number);
+  ta.assert<ta.Equal<ReturnType<typeof array['parse']>, number[]>>();
+  const rArray = ft.Readonly(array);
+  ta.assert<ta.Equal<ReturnType<typeof rArray['parse']>, readonly number[]>>();
+  expect(rArray.safeParse([10, 3])).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": Array [
+        10,
+        3,
+      ],
+    }
+  `);
+});

--- a/src/types/Readonly.ts
+++ b/src/types/Readonly.ts
@@ -1,0 +1,42 @@
+import { RuntypeBase } from '../runtype';
+import { Array as Arr, ReadonlyArray } from './array';
+import { InternalRecord, RecordFields } from './Object';
+import { Record, KeyRuntypeBase, ReadonlyRecord } from './Record';
+import { Tuple, ReadonlyTuple } from './tuple';
+
+export type Readonly<T extends RuntypeBase> = T extends InternalRecord<
+  infer TFields,
+  infer TPartial,
+  false
+>
+  ? InternalRecord<TFields, TPartial, true>
+  : T extends Arr<infer TElement>
+  ? ReadonlyArray<TElement>
+  : T extends Tuple<infer TElements>
+  ? ReadonlyTuple<TElements>
+  : T extends Record<infer K, infer V>
+  ? ReadonlyRecord<K, V>
+  : unknown;
+
+export function Readonly<TFields extends RecordFields, TPartial extends boolean>(
+  input: InternalRecord<TFields, TPartial, false>,
+): InternalRecord<TFields, TPartial, true>;
+export function Readonly<TElement extends RuntypeBase>(
+  input: Arr<TElement>,
+): ReadonlyArray<TElement>;
+export function Readonly<
+  TElements extends readonly RuntypeBase<unknown>[] = readonly RuntypeBase<unknown>[]
+>(input: Tuple<TElements>): ReadonlyTuple<TElements>;
+export function Readonly<K extends KeyRuntypeBase, V extends RuntypeBase<unknown>>(
+  record: Record<K, V>,
+): ReadonlyRecord<K, V>;
+export function Readonly(input: any): any {
+  const result = { ...input };
+  result.isReadonly = true;
+  for (const m of [`asPartial`, `pick`, `omit`]) {
+    if (typeof input[m] === 'function') {
+      result[m] = (...args: any[]) => Readonly(input[m](...args));
+    }
+  }
+  return result;
+}

--- a/src/types/Record.ts
+++ b/src/types/Record.ts
@@ -45,6 +45,15 @@ export interface Record<K extends KeyRuntypeBase, V extends RuntypeBase<unknown>
   readonly tag: 'record';
   readonly key: K;
   readonly value: V;
+  readonly isReadonly: false;
+}
+
+export interface ReadonlyRecord<K extends KeyRuntypeBase, V extends RuntypeBase<unknown>>
+  extends Codec<{ readonly [_ in Static<K>]?: Static<V> }> {
+  readonly tag: 'record';
+  readonly key: K;
+  readonly value: V;
+  readonly isReadonly: true;
 }
 
 /**
@@ -104,6 +113,7 @@ export function Record<K extends KeyRuntypeBase, V extends RuntypeBase<unknown>>
     {
       key,
       value,
+      isReadonly: false,
       show() {
         return `{ [_: ${show(key, false)}]: ${show(value, false)} }`;
       },

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -12,12 +12,24 @@ import show from '../show';
 export type StaticTuple<TElements extends readonly RuntypeBase<unknown>[]> = {
   [key in keyof TElements]: TElements[key] extends RuntypeBase<infer E> ? E : unknown;
 };
+export type ReadonlyStaticTuple<TElements extends readonly RuntypeBase<unknown>[]> = {
+  readonly [key in keyof TElements]: TElements[key] extends RuntypeBase<infer E> ? E : unknown;
+};
 
 export interface Tuple<
   TElements extends readonly RuntypeBase<unknown>[] = readonly RuntypeBase<unknown>[]
 > extends Codec<StaticTuple<TElements>> {
   readonly tag: 'tuple';
   readonly components: TElements;
+  readonly isReadonly: false;
+}
+
+export interface ReadonlyTuple<
+  TElements extends readonly RuntypeBase<unknown>[] = readonly RuntypeBase<unknown>[]
+> extends Codec<ReadonlyStaticTuple<TElements>> {
+  readonly tag: 'tuple';
+  readonly components: TElements;
+  readonly isReadonly: true;
 }
 
 export function isTupleRuntype(runtype: RuntypeBase): runtype is Tuple<readonly RuntypeBase[]> {
@@ -68,6 +80,7 @@ export function Tuple<
     },
     {
       components,
+      isReadonly: false,
       show() {
         return `[${(components as readonly RuntypeBase<unknown>[])
           .map(e => show(e, false))


### PR DESCRIPTION
This supports `Object`, `Array`, `Tuple` and `Record`. I have not removed the `asReadonly` utilities from `Object` or `Array`, but this `Readonly` helper should probably be preferred going forwards as it will lead to a lower bundle size because it can be shared among all types.

[closes #50]