### PR TITLE
Feat: add keyOf type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { Constraint, Guard } from './types/constraint';
 export { Enum } from './types/Enum';
 export { InstanceOf } from './types/instanceof';
 export { Intersect } from './types/intersect';
+export { KeyOf } from './types/KeyOf';
 export { Lazy } from './types/lazy';
 export type { LiteralValue } from './types/literal';
 export { Literal, Null, Undefined } from './types/literal';

--- a/src/types/KeyOf.spec.ts
+++ b/src/types/KeyOf.spec.ts
@@ -18,87 +18,87 @@ const MixedObjectKeys = {
 };
 
 test('Numeric Object Keys', () => {
-  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse(2)).toMatchInlineSnapshot(`
+  expect(KeyOf(NumbericObjectKeys).safeParse(2)).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": 2,
     }
   `);
-  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse('2')).toMatchInlineSnapshot(`
+  expect(KeyOf(NumbericObjectKeys).safeParse('2')).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": "2",
     }
   `);
-  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse('foobar')).toMatchInlineSnapshot(`
+  expect(KeyOf(NumbericObjectKeys).safeParse('foobar')).toMatchInlineSnapshot(`
     Object {
-      "message": "Expected NumericKeys, but was \\"foobar\\"",
+      "message": "Expected \\"2\\" | \\"4\\", but was \\"foobar\\"",
       "success": false,
     }
   `);
-  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse('5')).toMatchInlineSnapshot(`
+  expect(KeyOf(NumbericObjectKeys).safeParse('5')).toMatchInlineSnapshot(`
     Object {
-      "message": "Expected NumericKeys, but was \\"5\\"",
+      "message": "Expected \\"2\\" | \\"4\\", but was \\"5\\"",
       "success": false,
     }
   `);
-  const typed: keyof typeof NumbericObjectKeys = KeyOf('NumericKeys', NumbericObjectKeys).parse(2);
+  const typed: keyof typeof NumbericObjectKeys = KeyOf(NumbericObjectKeys).parse(2);
 
   expect(typed).toBe(2);
 
-  expect(show(KeyOf('NumericKeys', NumbericObjectKeys))).toMatchInlineSnapshot(`"NumericKeys"`);
+  expect(show(KeyOf(NumbericObjectKeys))).toMatchInlineSnapshot(`"\\"2\\" | \\"4\\""`);
 });
 
 test('String Object Keys', () => {
-  expect(KeyOf('StringKeys', StringObjectKeys).safeParse('foo')).toMatchInlineSnapshot(`
+  expect(KeyOf(StringObjectKeys).safeParse('foo')).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": "foo",
     }
   `);
-  expect(KeyOf('StringKeys', StringObjectKeys).safeParse(55)).toMatchInlineSnapshot(`
+  expect(KeyOf(StringObjectKeys).safeParse(55)).toMatchInlineSnapshot(`
     Object {
-      "message": "Expected StringKeys, but was 55",
+      "message": "Expected \\"bar\\" | \\"foo\\", but was 55",
       "success": false,
     }
   `);
-  const typed: keyof typeof StringObjectKeys = KeyOf('StringKeys', StringObjectKeys).parse('bar');
+  const typed: keyof typeof StringObjectKeys = KeyOf(StringObjectKeys).parse('bar');
 
   expect(typed).toBe('bar');
 
-  expect(show(KeyOf('StringKeys', NumbericObjectKeys))).toMatchInlineSnapshot(`"StringKeys"`);
+  expect(show(KeyOf(StringObjectKeys))).toMatchInlineSnapshot(`"\\"bar\\" | \\"foo\\""`);
 });
 
 test('Mixed Object Keys', () => {
-  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse('foo')).toMatchInlineSnapshot(`
+  expect(KeyOf(MixedObjectKeys).safeParse('foo')).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": "foo",
     }
   `);
-  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse(5)).toMatchInlineSnapshot(`
+  expect(KeyOf(MixedObjectKeys).safeParse(5)).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": 5,
     }
   `);
-  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse('foobar')).toMatchInlineSnapshot(`
+  expect(KeyOf(MixedObjectKeys).safeParse('foobar')).toMatchInlineSnapshot(`
     Object {
-      "message": "Expected MixedKeys, but was \\"foobar\\"",
+      "message": "Expected \\"4\\" | \\"5\\" | \\"foo\\", but was \\"foobar\\"",
       "success": false,
     }
   `);
-  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse(4)).toMatchInlineSnapshot(`
+  expect(KeyOf(MixedObjectKeys).safeParse(4)).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": 4,
     }
   `);
-  const stringNumber: keyof typeof MixedObjectKeys = KeyOf('MixedKeys', MixedObjectKeys).parse('4');
+  const stringNumber: keyof typeof MixedObjectKeys = KeyOf(MixedObjectKeys).parse('4');
   expect(stringNumber).toBe('4');
 
-  const number: keyof typeof MixedObjectKeys = KeyOf('MixedKeys', MixedObjectKeys).parse(5);
+  const number: keyof typeof MixedObjectKeys = KeyOf(MixedObjectKeys).parse(5);
   expect(number).toBe(5);
 
-  expect(show(KeyOf('MixedKeys', MixedObjectKeys))).toMatchInlineSnapshot(`"MixedKeys"`);
+  expect(show(KeyOf(MixedObjectKeys))).toMatchInlineSnapshot(`"\\"4\\" | \\"5\\" | \\"foo\\""`);
 });

--- a/src/types/KeyOf.spec.ts
+++ b/src/types/KeyOf.spec.ts
@@ -1,0 +1,104 @@
+import { KeyOf } from '..';
+import show from '../show';
+
+const StringObjectKeys = {
+  foo: 1,
+  bar: 2,
+}
+
+const NumbericObjectKeys = {
+  2: 1,
+  4: "2",
+}
+
+const MixedObjectKeys = {
+  foo: "bar",
+  5: 1,
+  "4": 3,
+}
+
+test('Numeric Object Keys', () => {
+  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse(2)).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": 2,
+    }
+  `);
+  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse("2")).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "2",
+    }
+  `);
+  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse('foobar')).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected NumericKeys, but was \\"foobar\\"",
+      "success": false,
+    }
+  `);
+  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse("5")).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected NumericKeys, but was \\"5\\"",
+      "success": false,
+    }
+  `);
+  const typed: keyof typeof NumbericObjectKeys = KeyOf('NumericKeys', NumbericObjectKeys).parse(2);
+
+  expect(typed).toBe(2);
+
+  expect(show(KeyOf('NumericKeys', NumbericObjectKeys))).toMatchInlineSnapshot(`"NumericKeys"`);
+});
+
+test('String Object Keys', () => {
+  expect(KeyOf('StringKeys', StringObjectKeys).safeParse('foo')).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "foo",
+    }
+  `);
+  expect(KeyOf('StringKeys', StringObjectKeys).safeParse(55)).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected StringKeys, but was 55",
+      "success": false,
+    }
+  `);
+  const typed: keyof typeof StringObjectKeys = KeyOf('StringKeys', StringObjectKeys).parse('bar');
+
+  expect(typed).toBe('bar');
+
+  expect(show(KeyOf('StringKeys', NumbericObjectKeys))).toMatchInlineSnapshot(`"StringKeys"`);
+});
+
+test('Mixed Object Keys', () => {
+  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse('foo')).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": "foo",
+    }
+  `);
+  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse(5)).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": 5,
+    }
+  `);
+  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse("foobar")).toMatchInlineSnapshot(`
+    Object {
+      "message": "Expected MixedKeys, but was \\"foobar\\"",
+      "success": false,
+    }
+  `);
+  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse(4)).toMatchInlineSnapshot(`
+    Object {
+      "success": true,
+      "value": 4,
+    }
+  `);
+  const stringNumber: keyof typeof MixedObjectKeys = KeyOf('MixedKeys', MixedObjectKeys).parse('4');
+  expect(stringNumber).toBe('4');
+
+  const number: keyof typeof MixedObjectKeys = KeyOf('MixedKeys', MixedObjectKeys).parse(5);
+  expect(number).toBe(5);
+
+  expect(show(KeyOf('MixedKeys', MixedObjectKeys))).toMatchInlineSnapshot(`"MixedKeys"`);
+});

--- a/src/types/KeyOf.spec.ts
+++ b/src/types/KeyOf.spec.ts
@@ -4,18 +4,18 @@ import show from '../show';
 const StringObjectKeys = {
   foo: 1,
   bar: 2,
-}
+};
 
 const NumbericObjectKeys = {
   2: 1,
-  4: "2",
-}
+  4: '2',
+};
 
 const MixedObjectKeys = {
-  foo: "bar",
+  foo: 'bar',
   5: 1,
-  "4": 3,
-}
+  '4': 3,
+};
 
 test('Numeric Object Keys', () => {
   expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse(2)).toMatchInlineSnapshot(`
@@ -24,7 +24,7 @@ test('Numeric Object Keys', () => {
       "value": 2,
     }
   `);
-  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse("2")).toMatchInlineSnapshot(`
+  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse('2')).toMatchInlineSnapshot(`
     Object {
       "success": true,
       "value": "2",
@@ -36,7 +36,7 @@ test('Numeric Object Keys', () => {
       "success": false,
     }
   `);
-  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse("5")).toMatchInlineSnapshot(`
+  expect(KeyOf('NumericKeys', NumbericObjectKeys).safeParse('5')).toMatchInlineSnapshot(`
     Object {
       "message": "Expected NumericKeys, but was \\"5\\"",
       "success": false,
@@ -82,7 +82,7 @@ test('Mixed Object Keys', () => {
       "value": 5,
     }
   `);
-  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse("foobar")).toMatchInlineSnapshot(`
+  expect(KeyOf('MixedKeys', MixedObjectKeys).safeParse('foobar')).toMatchInlineSnapshot(`
     Object {
       "message": "Expected MixedKeys, but was \\"foobar\\"",
       "success": false,

--- a/src/types/KeyOf.ts
+++ b/src/types/KeyOf.ts
@@ -1,0 +1,23 @@
+import { expected, success } from '../result';
+import { create, Codec } from '../runtype';
+
+export interface KeyOf<TObject extends Object>
+  extends Codec<keyof TObject> {
+  readonly tag: 'keyOf';
+  readonly keys: Set<string>;
+}
+
+export function KeyOf<TObject extends Object>(
+  name: string,
+  object: TObject,
+): KeyOf<TObject> {
+  const keys = new Set(Object.keys(object));
+  return create<KeyOf<TObject>>(
+    'keyOf',
+    value => (keys.has(typeof value === "number" ? value.toString() : value as any) ? success(value as any) : expected(name, value)),
+    {
+      keys,
+      show: () => name,
+    },
+  );
+}

--- a/src/types/KeyOf.ts
+++ b/src/types/KeyOf.ts
@@ -1,20 +1,19 @@
 import { expected, success } from '../result';
 import { create, Codec } from '../runtype';
 
-export interface KeyOf<TObject extends Object>
-  extends Codec<keyof TObject> {
+export interface KeyOf<TObject extends Object> extends Codec<keyof TObject> {
   readonly tag: 'keyOf';
   readonly keys: Set<string>;
 }
 
-export function KeyOf<TObject extends Object>(
-  name: string,
-  object: TObject,
-): KeyOf<TObject> {
+export function KeyOf<TObject extends Object>(name: string, object: TObject): KeyOf<TObject> {
   const keys = new Set(Object.keys(object));
   return create<KeyOf<TObject>>(
     'keyOf',
-    value => (keys.has(typeof value === "number" ? value.toString() : value as any) ? success(value as any) : expected(name, value)),
+    value =>
+      keys.has(typeof value === 'number' ? value.toString() : (value as any))
+        ? success(value as any)
+        : expected(name, value),
     {
       keys,
       show: () => name,

--- a/src/types/KeyOf.ts
+++ b/src/types/KeyOf.ts
@@ -1,13 +1,19 @@
+import { showValue } from '..';
 import { expected, success } from '../result';
 import { create, Codec } from '../runtype';
+import { parenthesize } from '../show';
 
 export interface KeyOf<TObject extends Object> extends Codec<keyof TObject> {
   readonly tag: 'keyOf';
   readonly keys: Set<string>;
 }
 
-export function KeyOf<TObject extends Object>(name: string, object: TObject): KeyOf<TObject> {
+export function KeyOf<TObject extends Object>(object: TObject): KeyOf<TObject> {
   const keys = new Set(Object.keys(object));
+  const name = [...keys]
+    .sort()
+    .map(k => showValue(k))
+    .join(` | `);
   return create<KeyOf<TObject>>(
     'keyOf',
     value =>
@@ -16,7 +22,7 @@ export function KeyOf<TObject extends Object>(name: string, object: TObject): Ke
         : expected(name, value),
     {
       keys,
-      show: () => name,
+      show: needsParens => parenthesize(name, needsParens),
     },
   );
 }


### PR DESCRIPTION
Adds a  KeyOf type that can be used like this
```ts
myObject = {
  foo: "bar",
  4: "foobar",
}

const keyOfObjectSchema = ft.KeyOf("nameOfMyObjectKeys", myObject)
```

Potential issue: Object.Keys(...) returns `string[]` and thus other types than string keys become degenerated which means that

```ts
keyOfObjectSchema.parse("4") // "4"
```
even though "4" is not a member of `keyof typeof myObject`. Furthermore, other types that are not number will always fail the parsing.

Since all js object fields becomes strings, perhaps one needs to enforce the keys to be strings in the first place?