### PR TITLE
fix: better union handling when discriminant is imperfect

### DIFF
--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -163,12 +163,24 @@ test('Upgrade Example', () => {
         Array [
           "The types of \\"version\\" are not compatible",
           Array [
-            "Expected 2, but was 1",
+            "Expected literal 2, but was 1",
+          ],
+        ],
+        Array [
+          "The types of \\"width\\" are not compatible",
+          Array [
+            "Expected number, but was undefined",
+          ],
+        ],
+        Array [
+          "The types of \\"height\\" are not compatible",
+          Array [
+            "Expected number, but was undefined",
           ],
         ],
       ],
       "key": "version",
-      "message": "Expected 2, but was 1",
+      "message": "Expected literal 2, but was 1",
       "success": false,
     }
   `);
@@ -184,7 +196,11 @@ test('Upgrade Example', () => {
     .toThrowErrorMatchingInlineSnapshot(`
     "Unable to assign {version: 1, size: 20} to { version: 2; width: number; height: number; }
       The types of \\"version\\" are not compatible
-        Expected 2, but was 1"
+        Expected literal 2, but was 1
+      The types of \\"width\\" are not compatible
+        Expected number, but was undefined
+      The types of \\"height\\" are not compatible
+        Expected number, but was undefined"
   `);
 });
 
@@ -530,26 +546,27 @@ test('Handles partial tests on parse', () => {
   // but this is only because it is not implemented
   expect(() => ResultType.assert(undefined)).toThrowErrorMatchingInlineSnapshot(`
     "Unable to assign undefined to { hello: \\"world\\"; } | ParsedValue<{}>
-      Unable to assign undefined to ParsedValue<{}>
-        ParsedValue<{}> does not support Runtype.test
-      And unable to assign undefined to Object"
+      Unable to assign undefined to { hello: \\"world\\"; }
+        Expected { hello: \\"world\\"; }, but was undefined
+      And unable to assign undefined to ParsedValue<{}>
+        ParsedValue<{}> does not support Runtype.test"
   `);
   expect(() => JsonType.assert(undefined)).toThrowErrorMatchingInlineSnapshot(`
     "Unable to assign undefined to { hello: \\"world\\"; } | ParsedValue<{}>
-      Unable to assign undefined to ParsedValue<{}>
-        ParsedValue<{}> does not support Runtype.test
-      And unable to assign undefined to Object"
+      Unable to assign undefined to { hello: \\"world\\"; }
+        Expected { hello: \\"world\\"; }, but was undefined
+      And unable to assign undefined to ParsedValue<{}>
+        ParsedValue<{}> does not support Runtype.test"
   `);
 
   // We used Sealed, so extra properties are not allowed
   expect(() => JsonType.assert({ hello: 'world', whatever: true }))
     .toThrowErrorMatchingInlineSnapshot(`
     "Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; } | ParsedValue<{}>
-      Unable to assign {hello: \\"world\\", whatever: true} to ParsedValue<{}>
-        ParsedValue<{}> does not support Runtype.test
-      And unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
-        Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
-          Unexpected property: whatever"
+      Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
+        Unexpected property: whatever
+      And unable to assign {hello: \\"world\\", whatever: true} to ParsedValue<{}>
+        ParsedValue<{}> does not support Runtype.test"
   `);
 
   // The basic parsing works
@@ -568,12 +585,11 @@ test('Handles partial tests on parse', () => {
   expect(showError(JsonType.safeParse(`{"hello": "world", "whatever": true}`) as any))
     .toMatchInlineSnapshot(`
     "Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; } | ParsedValue<{}>
-      Unable to assign {hello: \\"world\\", whatever: true} to {}
-        Unexpected property: hello
+      Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
         Unexpected property: whatever
-      And unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
-        Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
-          Unexpected property: whatever"
+      And unable to assign {hello: \\"world\\", whatever: true} to {}
+        Unexpected property: hello
+        Unexpected property: whatever"
   `);
 
   // We can serialize the normal object
@@ -590,8 +606,7 @@ test('Handles partial tests on parse', () => {
   expect(showError(JsonType.safeSerialize({ hello: 'world', whatever: true } as any) as any))
     .toMatchInlineSnapshot(`
     "Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
-      Unable to assign {hello: \\"world\\", whatever: true} to { hello: \\"world\\"; }
-        Unexpected property: whatever"
+      Unexpected property: whatever"
   `);
 
   // We still apply normal tests post-parse, so you can still use the `test` to add

--- a/src/types/ParsedValue.spec.ts
+++ b/src/types/ParsedValue.spec.ts
@@ -311,6 +311,25 @@ test('serialize can return an error', () => {
   `);
 });
 
+test('serialize returns an error if not implemented', () => {
+  const URLString = ParsedValue(String, {
+    parse(value) {
+      try {
+        return { success: true, value: new URL(value) };
+      } catch (ex) {
+        return { success: false, message: `Expected a valid URL but got '${value}'` };
+      }
+    },
+  });
+
+  expect(URLString.safeSerialize(new URL('https://example.com'))).toMatchInlineSnapshot(`
+    Object {
+      "message": "ParsedValue<string> does not support Runtype.serialize",
+      "success": false,
+    }
+  `);
+});
+
 test('Handle Being Within Cycles', () => {
   const TrimmedString = ParsedValue(String, {
     name: 'TrimmedString',

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -1,4 +1,4 @@
-import { Array, Union, String, Literal, Object, Number, InstanceOf, Tuple } from '..';
+import { Array, Union, String, Literal, Object, Number, InstanceOf, Tuple, Never, Named } from '..';
 import { Null } from './literal';
 
 const ThreeOrString = Union(Literal(3), String);
@@ -386,15 +386,15 @@ describe('union', () => {
       `);
 
       expect(() => extract([2, { size: 20 } as any])).toThrowErrorMatchingInlineSnapshot(`
-"Unable to assign [2, {size: 20}] to [1, { size: number; }] | [2, { width: number; height: number; }]
-  Unable to assign [2, {size: 20}] to [2, { width: number; height: number; }]
-    The types of [1] are not compatible
-      Unable to assign {size: 20} to { width: number; height: number; }
-        The types of \\"width\\" are not compatible
-          Expected number, but was undefined
-        The types of \\"height\\" are not compatible
-          Expected number, but was undefined"
-`);
+        "Unable to assign [2, {size: 20}] to [1, { size: number; }] | [2, { width: number; height: number; }]
+          Unable to assign [2, {size: 20}] to [2, { width: number; height: number; }]
+            The types of [1] are not compatible
+              Unable to assign {size: 20} to { width: number; height: number; }
+                The types of \\"width\\" are not compatible
+                  Expected number, but was undefined
+                The types of \\"height\\" are not compatible
+                  Expected number, but was undefined"
+      `);
     });
     it('should handle branded tags', () => {
       const Version1 = Tuple(Literal(1).withBrand('version'), Object({ size: Number }));
@@ -796,6 +796,129 @@ describe('union', () => {
         "message": "Expected { key: { value: string; }; body: string[]; } | { key: { value: number; }; body: string[]; }, but was {key: {value: 42}, body: [42]}",
         "success": false,
       }
+    `);
+  });
+  it('does not break when every value in the union is never', () => {
+    expect(Union(Never, Never).safeParse({ myValue: 42 })).toMatchInlineSnapshot(`
+      Object {
+        "fullError": Array [
+          "Unable to assign {myValue: 42} to never | never",
+          Array [
+            "Unable to assign {myValue: 42} to never",
+            Array [
+              "Expected nothing, but was {myValue: 42}",
+            ],
+          ],
+          Array [
+            "And unable to assign {myValue: 42} to never",
+            Array [
+              "Expected nothing, but was {myValue: 42}",
+            ],
+          ],
+        ],
+        "message": "Expected never | never, but was {myValue: 42}",
+        "success": false,
+      }
+    `);
+  });
+  it('can make use of imperfect discriminants', () => {
+    const Circle = Named(
+      'Circle',
+      Union(
+        Object({
+          type: Literal('CIRCLE'),
+          version: Literal(1),
+          radius: Number,
+        }),
+        Object({
+          type: Literal('CIRCLE'),
+          version: Literal(2),
+          radius: Number,
+          color: String,
+        }),
+      ),
+    );
+    expect(() => Circle.parse({ type: 'CIRCLE', version: 2, radius: 42 }))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"CIRCLE\\"; version: 1; radius: number; } | { type: \\"CIRCLE\\"; version: 2; radius: number; color: string; }
+        Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"CIRCLE\\"; version: 2; radius: number; color: string; }
+          The types of \\"color\\" are not compatible
+            Expected string, but was undefined"
+    `);
+
+    const MyUnion = Union(
+      Object({
+        type: Literal('SQUARE'),
+        version: Literal(1),
+        size: Number,
+      }),
+      Object({
+        type: Literal('SQUARE'),
+        version: Literal(2),
+        size: Number,
+        color: String,
+      }),
+      Circle,
+      Object({
+        type: Literal('RECTANGLE'),
+        version: Literal(1),
+        width: Number,
+        height: Number,
+        color: String,
+      }),
+    );
+    expect(() => MyUnion.assert({ type: 'RECTANGLE', version: 1, width: 10, height: 20 }))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unable to assign {type: \\"RECTANGLE\\", version: 1 ... } to { type: \\"SQUARE\\"; version: 1; size: number; } | { type: \\"SQUARE\\"; version: 2; size: number; color: string; } | Circle | { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }
+        Unable to assign {type: \\"RECTANGLE\\", version: 1 ... } to { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }
+          The types of \\"color\\" are not compatible
+            Expected string, but was undefined"
+    `);
+    expect(() => MyUnion.parse({ type: 'CIRCLE', version: 2, radius: 42 }))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"SQUARE\\"; version: 1; size: number; } | { type: \\"SQUARE\\"; version: 2; size: number; color: string; } | Circle | { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }
+        Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"CIRCLE\\"; version: 1; radius: number; } | { type: \\"CIRCLE\\"; version: 2; radius: number; color: string; }
+          Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"CIRCLE\\"; version: 2; radius: number; color: string; }
+            The types of \\"color\\" are not compatible
+              Expected string, but was undefined"
+    `);
+    expect(() => MyUnion.assert({ type: 'CIRCLE', version: 2, radius: 42 }))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"SQUARE\\"; version: 1; size: number; } | { type: \\"SQUARE\\"; version: 2; size: number; color: string; } | Circle | { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }
+        Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"CIRCLE\\"; version: 1; radius: number; } | { type: \\"CIRCLE\\"; version: 2; radius: number; color: string; }
+          Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"CIRCLE\\"; version: 2; radius: number; color: string; }
+            The types of \\"color\\" are not compatible
+              Expected string, but was undefined"
+    `);
+    expect(() => MyUnion.parse({ type: 'SQUARE', version: 2, size: 42 }))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 1; size: number; } | { type: \\"SQUARE\\"; version: 2; size: number; color: string; } | Circle | { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }
+        Unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 1; size: number; }
+          The types of \\"version\\" are not compatible
+            Expected literal 1, but was 2
+        And unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 2; size: number; color: string; }
+          The types of \\"color\\" are not compatible
+            Expected string, but was undefined"
+    `);
+    expect(() => MyUnion.assert({ type: 'SQUARE', version: 2, size: 42 }))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 1; size: number; } | { type: \\"SQUARE\\"; version: 2; size: number; color: string; } | Circle | { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }
+        Unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 1; size: number; }
+          The types of \\"version\\" are not compatible
+            Expected literal 1, but was 2
+        And unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 2; size: number; color: string; }
+          The types of \\"color\\" are not compatible
+            Expected string, but was undefined"
+    `);
+    expect(() => MyUnion.serialize({ type: 'SQUARE', version: 2, size: 42 } as any))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 1; size: number; } | { type: \\"SQUARE\\"; version: 2; size: number; color: string; } | Circle | { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }
+        Unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 1; size: number; }
+          The types of \\"version\\" are not compatible
+            Expected literal 1, but was 2
+        And unable to assign {type: \\"SQUARE\\", version: 2, size: 42} to { type: \\"SQUARE\\"; version: 2; size: number; color: string; }
+          The types of \\"color\\" are not compatible
+            Expected string, but was undefined"
     `);
   });
 });

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -838,6 +838,12 @@ describe('union', () => {
         }),
       ),
     );
+    expect(Circle.parse({ type: 'CIRCLE', version: 2, radius: 42, color: 'red' })).toEqual({
+      type: 'CIRCLE',
+      version: 2,
+      radius: 42,
+      color: 'red',
+    });
     expect(() => Circle.parse({ type: 'CIRCLE', version: 2, radius: 42 }))
       .toThrowErrorMatchingInlineSnapshot(`
       "Unable to assign {type: \\"CIRCLE\\", version: 2, radius: 42} to { type: \\"CIRCLE\\"; version: 1; radius: number; } | { type: \\"CIRCLE\\"; version: 2; radius: number; color: string; }
@@ -867,6 +873,21 @@ describe('union', () => {
         color: String,
       }),
     );
+    expect(MyUnion.parse({ type: 'SQUARE', version: 2, size: 42, color: 'red' })).toEqual({
+      type: 'SQUARE',
+      version: 2,
+      size: 42,
+      color: 'red',
+    });
+    expect(MyUnion.parse({ type: 'CIRCLE', version: 2, radius: 42, color: 'red' })).toEqual({
+      type: 'CIRCLE',
+      version: 2,
+      radius: 42,
+      color: 'red',
+    });
+    expect(
+      MyUnion.parse({ type: 'RECTANGLE', version: 1, width: 42, height: 8, color: 'red' }),
+    ).toEqual({ type: 'RECTANGLE', version: 1, width: 42, height: 8, color: 'red' });
     expect(() => MyUnion.assert({ type: 'RECTANGLE', version: 1, width: 10, height: 20 }))
       .toThrowErrorMatchingInlineSnapshot(`
       "Unable to assign {type: \\"RECTANGLE\\", version: 1 ... } to { type: \\"SQUARE\\"; version: 1; size: number; } | { type: \\"SQUARE\\"; version: 2; size: number; color: string; } | Circle | { type: \\"RECTANGLE\\"; version: 1; width: number; height: number; color: string; }

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -76,15 +76,23 @@ function findFields<TResult>(
     for (const fieldName of Object.keys(underlying.fields)) {
       pushField(fieldName, underlying.fields[fieldName]);
     }
-  }
-  if (isTupleRuntype(underlying)) {
+  } else if (isTupleRuntype(underlying)) {
     underlying.components.forEach((type, i) => {
       pushField(`${i}`, type);
     });
-  }
-  if (isIntersectRuntype(underlying)) {
+  } else if (isIntersectRuntype(underlying)) {
     for (const type of underlying.intersectees) {
       fields.push(...findFields(type, mode));
+    }
+  } else if (isUnionType(underlying)) {
+    const alternatives = underlying.alternatives.map(type => findFields(type, mode));
+    const fieldNames = intersect(alternatives.map(v => new Set(v.map(([fieldName]) => fieldName))));
+    for (const v of alternatives) {
+      for (const [fieldName, type] of v) {
+        if (fieldNames.has(fieldName)) {
+          pushField(fieldName, type);
+        }
+      }
     }
   }
   return fields;
@@ -101,34 +109,64 @@ function intersect<T>(sets: Set<T>[]) {
   }
   return result;
 }
+interface Discriminant<TResult> {
+  largestDiscriminant: number;
+  fieldTypes: Map<LiteralValue, Set<RuntypeBase<TResult>>>;
+}
+function createDiscriminant<TResult>(): Discriminant<TResult> {
+  return { largestDiscriminant: 0, fieldTypes: new Map() };
+}
 function findDiscriminator<TResult>(
   recordAlternatives: readonly (readonly [RuntypeBase<TResult>, [string, RuntypeBase][]])[],
 ) {
   const commonFieldNames = intersect(
     recordAlternatives.map(([, fields]) => new Set(fields.map(([fieldName]) => fieldName))),
   );
-  const commonLiteralFields = new Map<string, Map<LiteralValue, RuntypeBase<TResult>>>(
+
+  const commonLiteralFields = new Map<string, Discriminant<TResult>>(
     // we want to always check these props first, in case there are multiple possible keys
     // that can be used to discriminate
-    ['type', 'kind', 'tag', 'version'].map(fieldName => [fieldName, new Map()]),
+    ['type', 'kind', 'tag', 'version'].map(fieldName => [fieldName, createDiscriminant()]),
   );
   for (const [type, fields] of recordAlternatives) {
     for (const [fieldName, field] of fields) {
-      if (isLiteralRuntype(field)) {
-        const fieldTypes = mapGet(commonLiteralFields)(fieldName, () => new Map());
-        if (fieldTypes.has(field.value)) {
-          commonFieldNames.delete(fieldName);
+      if (commonFieldNames.has(fieldName)) {
+        if (isLiteralRuntype(field)) {
+          const discriminant = mapGet(commonLiteralFields)(fieldName, createDiscriminant);
+          const typesForThisDiscriminant = discriminant.fieldTypes.get(field.value);
+          if (typesForThisDiscriminant) {
+            typesForThisDiscriminant.add(type);
+            discriminant.largestDiscriminant = Math.max(
+              discriminant.largestDiscriminant,
+              typesForThisDiscriminant.size,
+            );
+          } else {
+            discriminant.largestDiscriminant = Math.max(discriminant.largestDiscriminant, 1);
+            discriminant.fieldTypes.set(field.value, new Set([type]));
+          }
         } else {
-          fieldTypes.set(field.value, type);
+          commonFieldNames.delete(fieldName);
         }
-      } else {
-        commonFieldNames.delete(fieldName);
       }
     }
   }
-  for (const [fieldName, fieldTypes] of commonLiteralFields) {
+  let bestDiscriminatorSize = Infinity;
+  for (const [fieldName, { largestDiscriminant }] of commonLiteralFields) {
     if (commonFieldNames.has(fieldName)) {
-      return [fieldName, fieldTypes] as const;
+      bestDiscriminatorSize = Math.min(bestDiscriminatorSize, largestDiscriminant);
+    }
+  }
+  if (bestDiscriminatorSize >= recordAlternatives.length) {
+    return undefined;
+  }
+  for (const [fieldName, { fieldTypes, largestDiscriminant }] of commonLiteralFields) {
+    if (largestDiscriminant === bestDiscriminatorSize && commonFieldNames.has(fieldName)) {
+      return [
+        fieldName,
+        new Map(
+          Array.from(fieldTypes).map(([fieldValue, types]) => [fieldValue, Array.from(types)]),
+        ),
+      ] as const;
     }
   }
 }
@@ -152,27 +190,54 @@ export function Union<
   }
   function validateWithKey(
     tag: string,
-    types: Map<LiteralValue, RuntypeBase<TResult>>,
+    types: Map<LiteralValue, RuntypeBase<TResult>[]>,
   ): InnerValidate {
-    const typesString = `${Array.from(types.values())
-      .map(v => show(v, true))
-      .join(' | ')}`;
+    const typeStrings = new Set<string>();
+    for (const t of types.values()) {
+      for (const v of t) {
+        typeStrings.add(show(v, true));
+      }
+    }
+    const typesString = Array.from(typeStrings).join(' | ');
     return (value, innerValidate) => {
       if (!value || typeof value !== 'object') {
         return expected(typesString, value);
       }
       const validator = types.get(value[tag]);
       if (validator) {
-        const result = innerValidate(validator, value);
-        if (!result.success) {
-          return failure(result.message, {
-            key: `<${/^\d+$/.test(tag) ? `[${tag}]` : tag}: ${showValue(value[tag])}>${
-              result.key ? `.${result.key}` : ``
-            }`,
-            fullError: unableToAssign(value, typesString, result),
-          });
+        if (validator.length === 1) {
+          const result = innerValidate(validator[0], value);
+          if (!result.success) {
+            return failure(result.message, {
+              key: `<${/^\d+$/.test(tag) ? `[${tag}]` : tag}: ${showValue(value[tag])}>${
+                result.key ? `.${result.key}` : ``
+              }`,
+              fullError: unableToAssign(value, typesString, result),
+            });
+          }
+          return result;
         }
-        return result;
+
+        let fullError: FullError | undefined;
+        for (const targetType of validator) {
+          const result = innerValidate(targetType, value);
+          if (result.success) {
+            return result;
+          }
+          if (!fullError) {
+            fullError = unableToAssign(
+              value,
+              runtype,
+              result.fullError || unableToAssign(value, targetType, result),
+            );
+          } else {
+            fullError.push(andError(result.fullError || unableToAssign(value, targetType, result)));
+          }
+        }
+
+        return expected(runtype, value, {
+          fullError,
+        });
       } else {
         const err = expected(
           Array.from(types.keys())
@@ -217,12 +282,19 @@ export function Union<
       });
     };
   }
+  function validateOnlyOption(innerType: RuntypeBase<TResult>): InnerValidate {
+    return (value, innerValidate) => innerValidate(innerType, value);
+  }
 
   // This must be lazy to avoid eagerly evaluating any circular references
   const validatorOf = (mode: 'p' | 's' | 't'): InnerValidate => {
-    const withFields = flatAlternatives
-      .filter(a => unwrapRuntype(a, mode).tag !== 'never')
-      .map(a => [a, findFields(a, mode)] as const);
+    const nonNeverAlternatives = flatAlternatives.filter(
+      a => unwrapRuntype(a, mode).tag !== 'never',
+    );
+    if (nonNeverAlternatives.length === 1) {
+      return validateOnlyOption(nonNeverAlternatives[0]);
+    }
+    const withFields = nonNeverAlternatives.map(a => [a, findFields(a, mode)] as const);
     const withAtLeastOneField = withFields.filter(a => a[1].length !== 0);
     const withNoFields = withFields.filter(a => a[1].length === 0);
     const discriminant = findDiscriminator(withAtLeastOneField);

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -218,26 +218,7 @@ export function Union<
           return result;
         }
 
-        let fullError: FullError | undefined;
-        for (const targetType of validator) {
-          const result = innerValidate(targetType, value);
-          if (result.success) {
-            return result;
-          }
-          if (!fullError) {
-            fullError = unableToAssign(
-              value,
-              runtype,
-              result.fullError || unableToAssign(value, targetType, result),
-            );
-          } else {
-            fullError.push(andError(result.fullError || unableToAssign(value, targetType, result)));
-          }
-        }
-
-        return expected(runtype, value, {
-          fullError,
-        });
+        return validateWithoutKeyInner(validator, value, innerValidate);
       } else {
         const err = expected(
           Array.from(types.keys())
@@ -258,29 +239,34 @@ export function Union<
     };
   }
 
-  function validateWithoutKey(alternatives: readonly RuntypeBase<TResult>[]): InnerValidate {
-    return (value, innerValidate) => {
-      let fullError: FullError | undefined;
-      for (const targetType of alternatives) {
-        const result = innerValidate(targetType, value);
-        if (result.success) {
-          return result as Result<TResult>;
-        }
-        if (!fullError) {
-          fullError = unableToAssign(
-            value,
-            runtype,
-            result.fullError || unableToAssign(value, targetType, result),
-          );
-        } else {
-          fullError.push(andError(result.fullError || unableToAssign(value, targetType, result)));
-        }
+  function validateWithoutKeyInner(
+    alternatives: readonly RuntypeBase<TResult>[],
+    value: any,
+    innerValidate: InnerValidateHelper,
+  ): Result<TResult> {
+    let fullError: FullError | undefined;
+    for (const targetType of alternatives) {
+      const result = innerValidate(targetType, value);
+      if (result.success) {
+        return result as Result<TResult>;
       }
+      if (!fullError) {
+        fullError = unableToAssign(
+          value,
+          runtype,
+          result.fullError || unableToAssign(value, targetType, result),
+        );
+      } else {
+        fullError.push(andError(result.fullError || unableToAssign(value, targetType, result)));
+      }
+    }
 
-      return expected(runtype, value, {
-        fullError,
-      });
-    };
+    return expected(runtype, value, {
+      fullError,
+    });
+  }
+  function validateWithoutKey(alternatives: readonly RuntypeBase<TResult>[]): InnerValidate {
+    return (value, innerValidate) => validateWithoutKeyInner(alternatives, value, innerValidate);
   }
   function validateOnlyOption(innerType: RuntypeBase<TResult>): InnerValidate {
     return (value, innerValidate) => innerValidate(innerType, value);


### PR DESCRIPTION
1. Unions with a single "alternative" are treated transparently as if they were that alternative.
2. The discriminant in a union can still be used if there are sometimes multiple objects with the same value for that discriminant.
3. We can still use discriminants even for nested unions inside "Named".
4. We don't use a discriminant if there is only one funtype that's an object type.